### PR TITLE
LQ_Base2026/07/06

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,6 +174,17 @@ find_path(QHYCCD_INCLUDE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/../../QUARCS_phd2/cameras"
 )
 
+set(QUARCS_QHY_HAS_CONTROL_CAA_ROTATOR OFF)
+if(QHYCCD_INCLUDE_DIR AND EXISTS "${QHYCCD_INCLUDE_DIR}/qhyccdstruct.h")
+  file(STRINGS "${QHYCCD_INCLUDE_DIR}/qhyccdstruct.h" _quarcs_qhy_caa_control
+    REGEX "CONTROL_CAA_ROTATOR")
+  if(_quarcs_qhy_caa_control)
+    set(QUARCS_QHY_HAS_CONTROL_CAA_ROTATOR ON)
+    add_compile_definitions(QUARCS_QHY_HAS_CONTROL_CAA_ROTATOR=1)
+  endif()
+  unset(_quarcs_qhy_caa_control)
+endif()
+
 if(CMAKE_SYSROOT AND TARGET StellarSolver::stellarsolver)
   get_target_property(_quarcs_stellarsolver_imported_links StellarSolver::stellarsolver INTERFACE_LINK_LIBRARIES)
   if(_quarcs_stellarsolver_imported_links)
@@ -427,6 +438,10 @@ add_executable(flatfield_batch_test
   guiding/GuidingStarDetector.h guiding/GuidingStarDetector.cpp
   guiding/CentroidUtils.h guiding/CentroidUtils.cpp
   guiding/flatfield/FlatFieldDetector.h guiding/flatfield/FlatFieldDetector.cpp
+  Logger.h Logger.cpp
+  websocketthread.h websocketthread.cpp
+  websocketclient.h websocketclient.cpp
+  mountstate.h
 )
 
 target_link_libraries(flatfield_batch_test PRIVATE
@@ -437,6 +452,11 @@ target_link_libraries(flatfield_batch_test PRIVATE
   Qt5::Widgets
   Qt5::Network
   Qt5::WebSockets
+  indiclient
+  ${ZLIB_LIBRARY}
+  ${NOVA_LIBRARIES}
+  qhyccd
+  ${StellarSolver_LIBS}
 )
 
 target_link_libraries(client PRIVATE
@@ -530,6 +550,7 @@ if(CMAKE_SYSROOT)
     target_link_libraries(client PRIVATE "${_QUARCS_ATLAS_BLAS}" "${_QUARCS_ATLAS_LAPACK}")
     target_link_libraries(guiding_offline_test PRIVATE "${_QUARCS_ATLAS_BLAS}" "${_QUARCS_ATLAS_LAPACK}")
     target_link_libraries(guiding_batch_analyzer PRIVATE "${_QUARCS_ATLAS_BLAS}" "${_QUARCS_ATLAS_LAPACK}")
+    target_link_libraries(flatfield_batch_test PRIVATE "${_QUARCS_ATLAS_BLAS}" "${_QUARCS_ATLAS_LAPACK}")
   endif()
   unset(_QUARCS_ATLAS_BLAS)
   unset(_QUARCS_ATLAS_LAPACK)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -86,6 +86,7 @@ SdkDeviceHandle sdkPoleScopeHandle = nullptr;  // SDK 极轴镜句柄
 SdkDeviceHandle sdkMainCameraHandle = nullptr; // SDK 主相机句柄
 SdkDeviceHandle sdkFocuserHandle   = nullptr;  // SDK 电调句柄
 SdkDeviceHandle sdkCFWHandle        = nullptr;  // SDK 滤镜轮句柄
+SdkDeviceHandle sdkCAAHandle        = nullptr;  // SDK 相机内置 CAA 旋转器句柄（复用相机 handle）
 
 QString sdkFocuserPort;  // SDK 电调串口路径
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -59,6 +59,7 @@ INDI::BaseDevice *dpPoleScope  = nullptr;  // 极轴镜设备指针
 INDI::BaseDevice *dpMainCamera = nullptr;  // 主相机设备指针
 INDI::BaseDevice *dpFocuser    = nullptr;  // 电调设备指针
 INDI::BaseDevice *dpCFW        = nullptr;  // 滤镜轮设备指针
+INDI::BaseDevice *dpRotator    = nullptr;  // CAA/旋转器设备指针
 
 namespace {
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -476,6 +476,7 @@ public:
     QVector<int> ConnectedTELESCOPEList;  // 已连接赤道仪索引
     QVector<int> ConnectedFOCUSERList;    // 已连接电调索引
     QVector<int> ConnectedFILTERList;     // 已连接滤镜轮索引
+    QVector<int> ConnectedROTATORList;    // 已连接 CAA/旋转器索引
     QVector<QString> ConnectDriverList;   // 已连接驱动名
     QVector<QString> INDI_Driver_List;    // INDI 驱动列表缓存
     QVector<ConnectedDevice> ConnectedDevices; // 已连接设备详细列表

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1709,7 +1709,10 @@ public:
     int glMainCameraBinning = 1;   // 主相机 bin
 
     bool isFilterOnCamera = false; // 滤镜是否内置相机
+    bool isCAAOnCamera = false;    // CAA 旋转器是否内置相机
     int sdkMainCfwSlotsCached = 0; // SDK 主相机内置 CFW 槽位缓存（>0 有效）
+    SdkControlParamInfo sdkMainCaaInfoCached; // SDK 主相机内置 CAA 范围/当前角度缓存
+    double sdkCaaAccumulatedOffset = 0.0; // SDK 主相机内置 CAA 本次连接期间累计相对旋转角度
     QString sdkMainCameraId;       // SDK 主相机 cameraId（用于 CFWList 等稳定 key；避免依赖 INDI 的 FILTER_NAME）
 
     /**

--- a/src/mainwindow_command_support.h
+++ b/src/mainwindow_command_support.h
@@ -13,6 +13,7 @@ extern INDI::BaseDevice *dpPoleScope;
 extern INDI::BaseDevice *dpMainCamera;
 extern INDI::BaseDevice *dpFocuser;
 extern INDI::BaseDevice *dpCFW;
+extern INDI::BaseDevice *dpRotator;
 
 extern SdkDeviceHandle sdkMountHandle;
 extern SdkDeviceHandle sdkGuiderHandle;

--- a/src/mainwindow_command_support.h
+++ b/src/mainwindow_command_support.h
@@ -20,6 +20,7 @@ extern SdkDeviceHandle sdkPoleScopeHandle;
 extern SdkDeviceHandle sdkMainCameraHandle;
 extern SdkDeviceHandle sdkFocuserHandle;
 extern SdkDeviceHandle sdkCFWHandle;
+extern SdkDeviceHandle sdkCAAHandle;
 extern QString sdkFocuserPort;
 extern QVector<SdkDeviceHandle> g_sdkQhyCamHandles;
 extern QVector<QString> g_sdkQhyCamIds;
@@ -49,6 +50,7 @@ inline int sdkUiIndexFromPoolIndex(int poolIndex)
 }
 
 inline constexpr int SDK_FOCUSER_UI_INDEX = -10001;
+inline constexpr int SDK_CAA_UI_INDEX = -10002;
 inline constexpr int kIndiFocuserRelMoveChunkMax = 10000;
 
 inline int sdkPoolIndexFromUiIndex(int uiIndex)
@@ -105,6 +107,59 @@ inline QString sdkCfwStorageKey(const QString &cameraId)
     if (!cameraId.isEmpty())
         return "SDK_CFW_" + cameraId;
     return "SDK_CFW_MainCamera";
+}
+
+inline QString sdkCaaDisplayName(const QString &cameraId)
+{
+    if (!cameraId.isEmpty())
+        return "CAA (on camera) - " + cameraId;
+    return "CAA (on camera)";
+}
+
+inline bool sdkGetCaaRotator(SdkDeviceHandle handle, SdkControlParamInfo &info, std::string *errMsg = nullptr)
+{
+    SdkCommand cmd;
+    cmd.type = SdkCommandType::Custom;
+    cmd.name = "GetCAARotator";
+    cmd.payload = std::any();
+
+    SdkResult res = SdkManager::instance().callByHandle(handle, cmd);
+    if (!res.success || !res.payload.has_value())
+    {
+        if (errMsg)
+            *errMsg = res.message;
+        return false;
+    }
+
+    try
+    {
+        info = std::any_cast<SdkControlParamInfo>(res.payload);
+        return true;
+    }
+    catch (const std::bad_any_cast &)
+    {
+        if (errMsg)
+            *errMsg = "GetCAARotator bad_any_cast";
+        return false;
+    }
+}
+
+inline bool sdkSetCaaRotator(SdkDeviceHandle handle, double angle, std::string *errMsg = nullptr)
+{
+    SdkCommand cmd;
+    cmd.type = SdkCommandType::Custom;
+    cmd.name = "SetCAARotator";
+    cmd.payload = angle;
+
+    SdkResult res = SdkManager::instance().callByHandle(handle, cmd);
+    if (!res.success)
+    {
+        if (errMsg)
+            *errMsg = res.message;
+        return false;
+    }
+
+    return true;
 }
 
 inline bool sdkGetCfwSlotsNum(SdkDeviceHandle handle, int &slotsNum, std::string *errMsg = nullptr)

--- a/src/mainwindow_commands_capture.cpp
+++ b/src/mainwindow_commands_capture.cpp
@@ -17,7 +17,10 @@ bool MainWindow::handleCaptureCommand(const QString &message, const QStringList 
             command == QLatin1String("SetCFWPosition") ||
             command == QLatin1String("CFWList") ||
             command == QLatin1String("getCFWList") ||
+            command == QLatin1String("SetCAARotator") ||
+            command == QLatin1String("getCAARotator") ||
             command == QLatin1String("SetBinning") ||
+
             command == QLatin1String("SetCameraTemperature") ||
             command == QLatin1String("SetCameraGain") ||
             command == QLatin1String("SetUsbTraffic") ||
@@ -395,6 +398,73 @@ bool MainWindow::handleCaptureCommand(const QString &message, const QStringList 
             }
         }
         Logger::Log("get CFWList finish!", LogLevel::DEBUG, DeviceType::CFW);
+    }
+
+    else if (parts[0].trimmed() == "SetCAARotator" && parts.size() == 2)
+    {
+        double angle = parts[1].trimmed().toDouble();
+        if (angle < -360.0) angle = -360.0;
+        if (angle > 360.0) angle = 360.0;
+
+        if (!isCAAOnCamera || !isMainCameraSDK() || sdkCAAHandle == nullptr)
+        {
+            emit wsThread->sendMessageToClient("SetCAARotatorFailed:caa_disconnected");
+            Logger::Log("SetCAARotator failed: caa_disconnected", LogLevel::WARNING, DeviceType::CAMERA);
+        }
+        else
+        {
+            std::string err;
+            if (sdkSetCaaRotator(sdkCAAHandle, angle, &err))
+            {
+                SdkControlParamInfo info;
+                if (sdkGetCaaRotator(sdkCAAHandle, info, &err))
+                    sdkMainCaaInfoCached = info;
+                else
+                    sdkMainCaaInfoCached.current = angle;
+
+                sdkCaaAccumulatedOffset += angle;
+                emit wsThread->sendMessageToClient("SetCAARotatorSuccess:" + QString::number(angle, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(sdkMainCaaInfoCached.current, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:" + QString::number(sdkCaaAccumulatedOffset, 'f', 2));
+                Logger::Log("SetCAARotator success angle=" + std::to_string(angle), LogLevel::INFO, DeviceType::CAMERA);
+            }
+            else
+            {
+                emit wsThread->sendMessageToClient("SetCAARotatorFailed:" + QString::fromStdString(err));
+                Logger::Log("SetCAARotator failed: " + err, LogLevel::WARNING, DeviceType::CAMERA);
+            }
+        }
+    }
+
+    else if (message == "getCAARotator")
+    {
+        if (!isCAAOnCamera || !isMainCameraSDK() || sdkCAAHandle == nullptr)
+        {
+            emit wsThread->sendMessageToClient("CAARotatorUnavailable");
+            Logger::Log("getCAARotator | CAA unavailable", LogLevel::DEBUG, DeviceType::CAMERA);
+        }
+        else
+        {
+            SdkControlParamInfo info;
+            std::string err;
+            if (sdkGetCaaRotator(sdkCAAHandle, info, &err))
+            {
+                sdkMainCaaInfoCached = info;
+                emit wsThread->sendMessageToClient(
+                    "CAARotatorRange:" +
+                    QString::number(info.minValue, 'f', 2) + ":" +
+                    QString::number(info.maxValue, 'f', 2) + ":" +
+                    QString::number(info.step, 'f', 2) + ":" +
+                    QString::number(info.current, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(info.current, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:" + QString::number(sdkCaaAccumulatedOffset, 'f', 2));
+            }
+            else
+            {
+                emit wsThread->sendMessageToClient("CAARotatorFailed:" + QString::fromStdString(err));
+                Logger::Log("getCAARotator failed: " + err, LogLevel::WARNING, DeviceType::CAMERA);
+            }
+        }
     }
 
     else if (parts.size() == 2 && parts[0].trimmed() == "SetBinning")

--- a/src/mainwindow_commands_capture.cpp
+++ b/src/mainwindow_commands_capture.cpp
@@ -19,6 +19,9 @@ bool MainWindow::handleCaptureCommand(const QString &message, const QStringList 
             command == QLatin1String("getCFWList") ||
             command == QLatin1String("SetCAARotator") ||
             command == QLatin1String("getCAARotator") ||
+            command == QLatin1String("AbortCAARotator") ||
+            command == QLatin1String("SetCAARotatorReverse") ||
+            command == QLatin1String("getCAARotatorReverse") ||
             command == QLatin1String("SetBinning") ||
 
             command == QLatin1String("SetCameraTemperature") ||
@@ -406,12 +409,7 @@ bool MainWindow::handleCaptureCommand(const QString &message, const QStringList 
         if (angle < -360.0) angle = -360.0;
         if (angle > 360.0) angle = 360.0;
 
-        if (!isCAAOnCamera || !isMainCameraSDK() || sdkCAAHandle == nullptr)
-        {
-            emit wsThread->sendMessageToClient("SetCAARotatorFailed:caa_disconnected");
-            Logger::Log("SetCAARotator failed: caa_disconnected", LogLevel::WARNING, DeviceType::CAMERA);
-        }
-        else
+        if (isCAAOnCamera && isMainCameraSDK() && sdkCAAHandle != nullptr)
         {
             std::string err;
             if (sdkSetCaaRotator(sdkCAAHandle, angle, &err))
@@ -434,16 +432,43 @@ bool MainWindow::handleCaptureCommand(const QString &message, const QStringList 
                 Logger::Log("SetCAARotator failed: " + err, LogLevel::WARNING, DeviceType::CAMERA);
             }
         }
+        else if (dpRotator != nullptr && dpRotator->isConnected())
+        {
+            if (indi_Client->setRotatorAngle(dpRotator, angle) == QHYCCD_SUCCESS)
+            {
+                double current = 0.0;
+                double min = 0.0;
+                double max = 0.0;
+                double step = 0.0;
+                if (indi_Client->getRotatorAngle(dpRotator, current, min, max, step) == QHYCCD_SUCCESS)
+                {
+                    emit wsThread->sendMessageToClient(
+                        "CAARotatorRange:" +
+                        QString::number(min, 'f', 2) + ":" +
+                        QString::number(max, 'f', 2) + ":" +
+                        QString::number(step, 'f', 2) + ":" +
+                        QString::number(current, 'f', 2));
+                    emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(current, 'f', 2));
+                }
+                emit wsThread->sendMessageToClient("SetCAARotatorSuccess:" + QString::number(angle, 'f', 2));
+                Logger::Log("SetCAARotator(INDI) success angle=" + std::to_string(angle), LogLevel::INFO, DeviceType::CAMERA);
+            }
+            else
+            {
+                emit wsThread->sendMessageToClient("SetCAARotatorFailed:indi_error");
+                Logger::Log("SetCAARotator(INDI) failed", LogLevel::WARNING, DeviceType::CAMERA);
+            }
+        }
+        else
+        {
+            emit wsThread->sendMessageToClient("SetCAARotatorFailed:caa_disconnected");
+            Logger::Log("SetCAARotator failed: caa_disconnected", LogLevel::WARNING, DeviceType::CAMERA);
+        }
     }
 
     else if (message == "getCAARotator")
     {
-        if (!isCAAOnCamera || !isMainCameraSDK() || sdkCAAHandle == nullptr)
-        {
-            emit wsThread->sendMessageToClient("CAARotatorUnavailable");
-            Logger::Log("getCAARotator | CAA unavailable", LogLevel::DEBUG, DeviceType::CAMERA);
-        }
-        else
+        if (isCAAOnCamera && isMainCameraSDK() && sdkCAAHandle != nullptr)
         {
             SdkControlParamInfo info;
             std::string err;
@@ -464,6 +489,76 @@ bool MainWindow::handleCaptureCommand(const QString &message, const QStringList 
                 emit wsThread->sendMessageToClient("CAARotatorFailed:" + QString::fromStdString(err));
                 Logger::Log("getCAARotator failed: " + err, LogLevel::WARNING, DeviceType::CAMERA);
             }
+        }
+        else if (dpRotator != nullptr && dpRotator->isConnected())
+        {
+            double angle = 0.0;
+            double min = 0.0;
+            double max = 0.0;
+            double step = 0.0;
+            if (indi_Client->getRotatorAngle(dpRotator, angle, min, max, step) == QHYCCD_SUCCESS)
+            {
+                emit wsThread->sendMessageToClient(
+                    "CAARotatorRange:" +
+                    QString::number(min, 'f', 2) + ":" +
+                    QString::number(max, 'f', 2) + ":" +
+                    QString::number(step, 'f', 2) + ":" +
+                    QString::number(angle, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(angle, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:0.00");
+            }
+            else
+            {
+                emit wsThread->sendMessageToClient("CAARotatorFailed:indi_error");
+                Logger::Log("getCAARotator(INDI) failed", LogLevel::WARNING, DeviceType::CAMERA);
+            }
+        }
+        else
+        {
+            emit wsThread->sendMessageToClient("CAARotatorUnavailable");
+            Logger::Log("getCAARotator | CAA unavailable", LogLevel::DEBUG, DeviceType::CAMERA);
+        }
+    }
+
+    else if (message == "AbortCAARotator")
+    {
+        if (dpRotator != nullptr && dpRotator->isConnected() &&
+            indi_Client->abortRotatorMove(dpRotator) == QHYCCD_SUCCESS)
+        {
+            emit wsThread->sendMessageToClient("AbortCAARotatorSuccess");
+        }
+        else
+        {
+            emit wsThread->sendMessageToClient("AbortCAARotatorFailed:caa_disconnected_or_unsupported");
+        }
+    }
+
+    else if (parts.size() == 2 && parts[0].trimmed() == "SetCAARotatorReverse")
+    {
+        const QString value = parts[1].trimmed().toLower();
+        const bool reversed = (value == "true" || value == "1" || value == "on" || value == "yes");
+        if (dpRotator != nullptr && dpRotator->isConnected() &&
+            indi_Client->setRotatorReverse(dpRotator, reversed) == QHYCCD_SUCCESS)
+        {
+            emit wsThread->sendMessageToClient("CAARotatorReverse:" + QString(reversed ? "true" : "false"));
+        }
+        else
+        {
+            emit wsThread->sendMessageToClient("SetCAARotatorReverseFailed:caa_disconnected_or_unsupported");
+        }
+    }
+
+    else if (message == "getCAARotatorReverse")
+    {
+        bool reversed = false;
+        if (dpRotator != nullptr && dpRotator->isConnected() &&
+            indi_Client->getRotatorReverse(dpRotator, reversed) == QHYCCD_SUCCESS)
+        {
+            emit wsThread->sendMessageToClient("CAARotatorReverse:" + QString(reversed ? "true" : "false"));
+        }
+        else
+        {
+            emit wsThread->sendMessageToClient("CAARotatorReverseUnavailable");
         }
     }
 

--- a/src/mainwindow_device_config.cpp
+++ b/src/mainwindow_device_config.cpp
@@ -370,6 +370,7 @@ QString MainWindow::getSDKDriverName(const QString& deviceType)
     // CFW（外置滤镜轮）在 system_devices[21]
     else if (deviceType == "CFW") index = 21;
     else if (deviceType == "Focuser") index = 22;
+    else if (deviceType == "Rotator" || deviceType == "CAA") index = 24;
     // ... 可以继续添加其他设备类型的映射
 
     if (index < 0 || index >= systemdevicelist.system_devices.size())
@@ -656,6 +657,22 @@ void MainWindow::cleanupQhySdkPoolAndResource(const QString& reason, const QStri
         ShootStatus = "IDLE";
         glIsFocusingLooping = false;
         isFocusLoopShooting = false;
+        isFilterOnCamera = false;
+        sdkMainCfwSlotsCached = 0;
+        isCAAOnCamera = false;
+        sdkCAAHandle = nullptr;
+        sdkMainCaaInfoCached = SdkControlParamInfo{};
+        sdkCaaAccumulatedOffset = 0.0;
+        SdkManager::instance().unregisterDevice("Rotator");
+        resetDeviceEntry(24);
+        if (systemdevicelist.system_devices.size() > 24)
+        {
+            systemdevicelist.system_devices[24].Description.clear();
+            systemdevicelist.system_devices[24].DriverIndiName.clear();
+            systemdevicelist.system_devices[24].SDKDriverName.clear();
+            systemdevicelist.system_devices[24].DriverFrom.clear();
+            systemdevicelist.system_devices[24].isSDKConnect = false;
+        }
     };
 
     auto makeCancelExposureCmd = [&]() {
@@ -959,6 +976,20 @@ void MainWindow::getConnectedDevices()
                 indi_Client->getCFWPosition(dpMainCamera, pos, min, max);
                 Logger::Log("getConnectedDevices | getCFWPosition: " + std::to_string(min) + ", " + std::to_string(max) + ", " + std::to_string(pos), LogLevel::INFO, DeviceType::MAIN);
                 emit wsThread->sendMessageToClient("CFWPositionMax:" + QString::number(max));
+            }
+
+            if (isCAAOnCamera && sdkCAAHandle != nullptr)
+            {
+                const QString caaDisplayName = sdkCaaDisplayName(sdkMainCameraId);
+                emit wsThread->sendMessageToClient("ConnectSuccess:Rotator:" + caaDisplayName + ":" + QString::fromLatin1("indi_qhy_ccd"));
+                emit wsThread->sendMessageToClient(
+                    "CAARotatorRange:" +
+                    QString::number(sdkMainCaaInfoCached.minValue, 'f', 2) + ":" +
+                    QString::number(sdkMainCaaInfoCached.maxValue, 'f', 2) + ":" +
+                    QString::number(sdkMainCaaInfoCached.step, 'f', 2) + ":" +
+                    QString::number(sdkMainCaaInfoCached.current, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(sdkMainCaaInfoCached.current, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:" + QString::number(sdkCaaAccumulatedOffset, 'f', 2));
             }
         }
         else if (ConnectedDevices[i].DeviceType == "Guider" && (dpGuider != nullptr || sdkGuiderHandle != nullptr))
@@ -1284,6 +1315,23 @@ void MainWindow::loadBindDeviceTypeList()
                     {
                         Logger::Log("LoadBindDeviceTypeList | MainCamera is in SDK mode but sdkMainCameraHandle is nullptr", LogLevel::WARNING, DeviceType::MAIN);
                     }
+
+                    if (isCAAOnCamera && sdkCAAHandle != nullptr)
+                    {
+                        const QString caaDisplayName = sdkCaaDisplayName(sdkMainCameraId);
+                        order += ":Rotator:" + caaDisplayName + ":" +
+                                 QString::fromLatin1("indi_qhy_ccd") + ":" +
+                                 (systemdevicelist.system_devices[i].isBind ? "true" : "false");
+
+                        emit wsThread->sendMessageToClient(
+                            "CAARotatorRange:" +
+                            QString::number(sdkMainCaaInfoCached.minValue, 'f', 2) + ":" +
+                            QString::number(sdkMainCaaInfoCached.maxValue, 'f', 2) + ":" +
+                            QString::number(sdkMainCaaInfoCached.step, 'f', 2) + ":" +
+                            QString::number(sdkMainCaaInfoCached.current, 'f', 2));
+                        emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(sdkMainCaaInfoCached.current, 'f', 2));
+                        emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:" + QString::number(sdkCaaAccumulatedOffset, 'f', 2));
+                    }
                 }
             }
             else if (systemdevicelist.system_devices[i].Description == "Guider" && systemdevicelist.system_devices[i].isBind)
@@ -1359,6 +1407,11 @@ void MainWindow::loadBindDeviceList(MyClient *client)
         {
             Logger::Log("LoadBindDeviceList | skip SDK Focuser: no valid port/name", LogLevel::WARNING, DeviceType::FOCUSER);
         }
+    }
+
+    if (isCAAOnCamera && sdkCAAHandle != nullptr)
+    {
+        appendDeviceToOrder("Rotator", sdkCaaDisplayName(sdkMainCameraId), SDK_CAA_UI_INDEX);
     }
 
     // 再追加 INDI 已连接设备（保持原有协议）

--- a/src/mainwindow_device_config.cpp
+++ b/src/mainwindow_device_config.cpp
@@ -302,6 +302,11 @@ bool MainWindow::indi_Driver_Confirm(QString DriverName, QString BaudRate)
         systemdevicelist.system_devices[systemdevicelist.currentDeviceCode].BaudRate = BaudRate.toInt();
         Logger::Log("indi_Driver_Confirm | Focuser | DriverName: " + DriverName.toStdString() + " BaudRate: " + std::to_string(BaudRate.toInt()), LogLevel::INFO, DeviceType::MAIN);
         break;
+    case 24:
+        systemdevicelist.system_devices[systemdevicelist.currentDeviceCode].Description = "Rotator";
+        systemdevicelist.system_devices[systemdevicelist.currentDeviceCode].BaudRate = BaudRate.toInt();
+        Logger::Log("indi_Driver_Confirm | Rotator | DriverName: " + DriverName.toStdString() + " BaudRate: " + std::to_string(BaudRate.toInt()), LogLevel::INFO, DeviceType::MAIN);
+        break;
 
     default:
         Logger::Log("indi_Driver_Confirm | Invalid currentDeviceCode: " + std::to_string(systemdevicelist.currentDeviceCode), LogLevel::ERROR, DeviceType::MAIN);
@@ -997,6 +1002,23 @@ void MainWindow::getConnectedDevices()
             emit wsThread->sendMessageToClient("GuiderOffsetRange:" + QString::number(glGuiderOffsetMin) + ":" + QString::number(glGuiderOffsetMax) + ":" + QString::number(glGuiderOffsetValue));
             emit wsThread->sendMessageToClient("GuiderGainRange:" + QString::number(glGuiderGainMin) + ":" + QString::number(glGuiderGainMax) + ":" + QString::number(glGuiderGainValue));
         }
+        else if (ConnectedDevices[i].DeviceType == "Rotator" && dpRotator != nullptr)
+        {
+            double angle = 0.0;
+            double min = 0.0;
+            double max = 0.0;
+            double step = 0.0;
+            if (indi_Client->getRotatorAngle(dpRotator, angle, min, max, step) == QHYCCD_SUCCESS)
+            {
+                emit wsThread->sendMessageToClient(
+                    "CAARotatorRange:" +
+                    QString::number(min, 'f', 2) + ":" +
+                    QString::number(max, 'f', 2) + ":" +
+                    QString::number(step, 'f', 2) + ":" +
+                    QString::number(angle, 'f', 2));
+                emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(angle, 'f', 2));
+            }
+        }
     }
     Logger::Log("getConnectedDevices finish!", LogLevel::INFO, DeviceType::MAIN);
 }
@@ -1339,6 +1361,24 @@ void MainWindow::loadBindDeviceTypeList()
                 emit wsThread->sendMessageToClient("GuiderOffsetRange:" + QString::number(glGuiderOffsetMin) + ":" + QString::number(glGuiderOffsetMax) + ":" + QString::number(glGuiderOffsetValue));
                 emit wsThread->sendMessageToClient("GuiderGainRange:" + QString::number(glGuiderGainMin) + ":" + QString::number(glGuiderGainMax) + ":" + QString::number(glGuiderGainValue));
             }
+            else if (systemdevicelist.system_devices[i].Description == "Rotator" && systemdevicelist.system_devices[i].isBind && dpRotator != nullptr)
+            {
+                double angle = 0.0;
+                double min = 0.0;
+                double max = 0.0;
+                double step = 0.0;
+                if (indi_Client->getRotatorAngle(dpRotator, angle, min, max, step) == QHYCCD_SUCCESS)
+                {
+                    emit wsThread->sendMessageToClient(
+                        "CAARotatorRange:" +
+                        QString::number(min, 'f', 2) + ":" +
+                        QString::number(max, 'f', 2) + ":" +
+                        QString::number(step, 'f', 2) + ":" +
+                        QString::number(angle, 'f', 2));
+                    emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(angle, 'f', 2));
+                    emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:0.00");
+                }
+            }
         }
     }
     Logger::Log("LoadBindDeviceTypeList | Bind Device Type List:" + order.toStdString(), LogLevel::INFO, DeviceType::MAIN);
@@ -1456,6 +1496,7 @@ void MainWindow::loadBindDeviceList(MyClient *client)
             else if (iface & INDI::BaseDevice::FILTER_INTERFACE) type = "CFW";
             else if (iface & INDI::BaseDevice::TELESCOPE_INTERFACE) type = "Mount";
             else if (iface & INDI::BaseDevice::FOCUSER_INTERFACE) type = "Focuser";
+            else if (iface & INDI::BaseDevice::ROTATOR_INTERFACE) type = "Rotator";
             // 待分配设备列表中暂时不展示 Mount（望远镜）项
             if (type == "Mount")
                 continue;

--- a/src/mainwindow_device_connection.cpp
+++ b/src/mainwindow_device_connection.cpp
@@ -2688,6 +2688,19 @@ void MainWindow::BindingDevice(QString DeviceType, int DeviceIndex)
         AfterDeviceConnect(dpCFW);
         Logger::Log("Binding CFW Device end !", LogLevel::INFO, DeviceType::MAIN);
     }
+    else if (DeviceType == "Rotator" || DeviceType == "CAA")
+    {
+        Logger::Log("Binding Rotator Device start ...", LogLevel::INFO, DeviceType::MAIN);
+        dpRotator = device;
+        if (systemdevicelist.system_devices.size() > 24) {
+            systemdevicelist.system_devices[24].Description = "Rotator";
+            systemdevicelist.system_devices[24].isConnect = true;
+            systemdevicelist.system_devices[24].isBind = true;
+        }
+        Tools::saveSystemDeviceList(systemdevicelist);
+        AfterDeviceConnect(dpRotator);
+        Logger::Log("Binding Rotator Device end !", LogLevel::INFO, DeviceType::MAIN);
+    }
 }
 void MainWindow::UnBindingDevice(QString DeviceType)
 {
@@ -2976,6 +2989,34 @@ void MainWindow::UnBindingDevice(QString DeviceType)
         Tools::saveSystemDeviceList(systemdevicelist);
 
         emit wsThread->sendMessageToClient("DeviceToBeAllocated:CFW:" + QString::number(DeviceIndex) + ":" + QString::fromUtf8(indi_Client->GetDeviceFromList(DeviceIndex)->getDeviceName()));
+    }
+    else if (DeviceType == "Rotator" || DeviceType == "CAA")
+    {
+        if (!dpRotator)
+        {
+            Logger::Log("UnBinding Rotator Device skipped: dpRotator is nullptr", LogLevel::WARNING, DeviceType::MAIN);
+            return;
+        }
+
+        int DeviceIndex = -1;
+        for (int i = 0; i < indi_Client->GetDeviceCount(); i++)
+        {
+            if (indi_Client->GetDeviceFromList(i)->getDeviceName() == dpRotator->getDeviceName())
+            {
+                DeviceIndex = i;
+                break;
+            }
+        }
+        if (systemdevicelist.system_devices.size() > 24)
+        {
+            systemdevicelist.system_devices[24].isBind = false;
+            systemdevicelist.system_devices[24].DeviceIndiName = "";
+        }
+        dpRotator = nullptr;
+        Tools::saveSystemDeviceList(systemdevicelist);
+
+        if (DeviceIndex >= 0 && DeviceIndex < indi_Client->GetDeviceCount())
+            emit wsThread->sendMessageToClient("DeviceToBeAllocated:Rotator:" + QString::number(DeviceIndex) + ":" + QString::fromUtf8(indi_Client->GetDeviceFromList(DeviceIndex)->getDeviceName()));
     }
 
     indi_Client->PrintDevices();
@@ -4477,6 +4518,51 @@ void MainWindow::AfterDeviceConnect(INDI::BaseDevice *dp)
         }
         Logger::Log("CFW connected successfully.", LogLevel::INFO, DeviceType::MAIN);
         emit wsThread->sendMessageToClient("ConnectSuccess:CFW:" + QString::fromUtf8(dpCFW->getDeviceName()) + ":" + QString::fromUtf8(dpCFW->getDriverExec()));
+    }
+
+    if (dpRotator == dp)
+    {
+        const QString deviceName = QString::fromUtf8(dpRotator->getDeviceName());
+        const QString driverExec = QString::fromUtf8(dpRotator->getDriverExec());
+        Logger::Log("Rotator connected after Device(" + deviceName.toStdString() + ") Connect: " + deviceName.toStdString(),
+                    LogLevel::INFO, DeviceType::MAIN);
+
+        ConnectedDevices.push_back({"Rotator", deviceName});
+
+        if (systemdevicelist.system_devices.size() > 24)
+        {
+            systemdevicelist.system_devices[24].Description = "Rotator";
+            systemdevicelist.system_devices[24].DeviceIndiName = deviceName;
+            systemdevicelist.system_devices[24].DriverFrom = "INDI";
+            systemdevicelist.system_devices[24].isSDKConnect = false;
+            systemdevicelist.system_devices[24].isBind = true;
+        }
+
+        indi_Client->GetAllPropertyName(dpRotator);
+
+        double angle = 0.0;
+        double min = 0.0;
+        double max = 0.0;
+        double step = 0.0;
+        if (indi_Client->getRotatorAngle(dpRotator, angle, min, max, step) == QHYCCD_SUCCESS)
+        {
+            emit wsThread->sendMessageToClient(
+                "CAARotatorRange:" +
+                QString::number(min, 'f', 2) + ":" +
+                QString::number(max, 'f', 2) + ":" +
+                QString::number(step, 'f', 2) + ":" +
+                QString::number(angle, 'f', 2));
+            emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(angle, 'f', 2));
+            emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:0.00");
+        }
+        else
+        {
+            Logger::Log("AfterDeviceConnect | Rotator connected but ABS_ROTATOR_ANGLE is unavailable",
+                        LogLevel::WARNING, DeviceType::MAIN);
+        }
+
+        Logger::Log("Rotator connected successfully.", LogLevel::INFO, DeviceType::MAIN);
+        emit wsThread->sendMessageToClient("ConnectSuccess:Rotator:" + deviceName + ":" + driverExec);
     }
 
     if (dpPoleScope == dp)
@@ -7741,6 +7827,12 @@ void MainWindow::ConnectDriver(QString DriverName, QString DriverType)
             systemdevicelist.system_devices[22].Description = "Focuser";
             systemdevicelist.system_devices[22].DriverIndiName = DriverName;
         }
+        else if (DriverType == "Rotator" || DriverType == "CAA")
+        {
+            driverCode = 24;
+            systemdevicelist.system_devices[24].Description = "Rotator";
+            systemdevicelist.system_devices[24].DriverIndiName = DriverName;
+        }
         else
         {
             Logger::Log("ConnectDriver | DriverType(" + DriverType.toStdString() + ") is not supported.", LogLevel::WARNING, DeviceType::MAIN);
@@ -8160,6 +8252,7 @@ void MainWindow::ConnectDriver(QString DriverName, QString DriverType)
     ConnectedTELESCOPEList.clear();
     ConnectedFOCUSERList.clear();
     ConnectedFILTERList.clear();
+    ConnectedROTATORList.clear();
 
     // 判断连接设备的类型
     for (int i = 0; i < connectedDeviceIdList.size(); i++)
@@ -8186,6 +8279,11 @@ void MainWindow::ConnectDriver(QString DriverName, QString DriverType)
                 Logger::Log("ConnectDriver | We received a FOCUSER!", LogLevel::INFO, DeviceType::MAIN);
                 ConnectedFOCUSERList.push_back(connectedDeviceIdList[i]);
             }
+            else if (indi_Client->GetDeviceFromList(connectedDeviceIdList[i])->getDriverInterface() & INDI::BaseDevice::ROTATOR_INTERFACE)
+            {
+                Logger::Log("ConnectDriver | We received a ROTATOR!", LogLevel::INFO, DeviceType::MAIN);
+                ConnectedROTATORList.push_back(connectedDeviceIdList[i]);
+            }
         }
         else
         {
@@ -8211,6 +8309,7 @@ void MainWindow::ConnectDriver(QString DriverName, QString DriverType)
     Logger::Log("ConnectDriver | Number of Connected TELESCOPE:" + std::to_string(ConnectedTELESCOPEList.size()), LogLevel::INFO, DeviceType::MAIN);
     Logger::Log("ConnectDriver | Number of Connected FOCUSER:" + std::to_string(ConnectedFOCUSERList.size()), LogLevel::INFO, DeviceType::MAIN);
     Logger::Log("ConnectDriver | Number of Connected FILTER:" + std::to_string(ConnectedFILTERList.size()), LogLevel::INFO, DeviceType::MAIN);
+    Logger::Log("ConnectDriver | Number of Connected ROTATOR:" + std::to_string(ConnectedROTATORList.size()), LogLevel::INFO, DeviceType::MAIN);
 
     auto savedDeviceNameByDescription = [&](const QString &description) -> QString
     {
@@ -8759,6 +8858,53 @@ void MainWindow::ConnectDriver(QString DriverName, QString DriverType)
                 if (device != nullptr) {
                     hasPendingAllocation = true;
                     emit wsThread->sendMessageToClient("DeviceToBeAllocated:CFW:" + QString::number(ConnectedFILTERList[i]) + ":" + QString::fromUtf8(device->getDeviceName()));
+                }
+            }
+        }
+    }
+
+    if (ConnectedROTATORList.size() == 1)
+    {
+        Logger::Log("ConnectDriver | Rotator Connected Success!", LogLevel::INFO, DeviceType::MAIN);
+        if (!ConnectedROTATORList.empty() && ConnectedROTATORList[0] >= 0 && ConnectedROTATORList[0] < indi_Client->GetDeviceCount()) {
+            INDI::BaseDevice *device = indi_Client->GetDeviceFromList(ConnectedROTATORList[0]);
+            if (device != nullptr) {
+                dpRotator = device;
+                if (systemdevicelist.system_devices.size() > 24) {
+                    systemdevicelist.system_devices[24].isConnect = true;
+                }
+                AfterDeviceConnect(dpRotator);
+            }
+        }
+    }
+    else if (ConnectedROTATORList.size() > 1)
+    {
+        EachDeviceOne = false;
+        const int boundRotatorIndex = findConnectedIndexBySavedName(ConnectedROTATORList, savedDeviceNameByDescription("Rotator"));
+        if (boundRotatorIndex >= 0)
+        {
+            INDI::BaseDevice *device = indi_Client->GetDeviceFromList(boundRotatorIndex);
+            if (device != nullptr)
+            {
+                dpRotator = device;
+                if (systemdevicelist.system_devices.size() > 24)
+                    systemdevicelist.system_devices[24].isConnect = true;
+                AfterDeviceConnect(dpRotator);
+                Logger::Log("ConnectDriver | INDI Rotator auto-bound by saved name: " +
+                                QString::fromUtf8(device->getDeviceName()).toStdString(),
+                            LogLevel::INFO, DeviceType::MAIN);
+            }
+        }
+
+        for (int i = 0; i < ConnectedROTATORList.size(); i++)
+        {
+            if (ConnectedROTATORList[i] == boundRotatorIndex)
+                continue;
+            if (ConnectedROTATORList[i] >= 0 && ConnectedROTATORList[i] < indi_Client->GetDeviceCount()) {
+                INDI::BaseDevice *device = indi_Client->GetDeviceFromList(ConnectedROTATORList[i]);
+                if (device != nullptr) {
+                    hasPendingAllocation = true;
+                    emit wsThread->sendMessageToClient("DeviceToBeAllocated:Rotator:" + QString::number(ConnectedROTATORList[i]) + ":" + QString::fromUtf8(device->getDeviceName()));
                 }
             }
         }
@@ -9449,6 +9595,19 @@ void MainWindow::DisconnectDevice(MyClient *client, QString DeviceName, QString 
         // systemdevicelist.system_devices[21].DriverIndiName = "";  // ❌ 不应清空（驱动名）
         // systemdevicelist.system_devices[21].DriverFrom = "";  // ❌ 不应清空（驱动能力）
         systemdevicelist.system_devices[21].dp = NULL;
+    }
+    else if (DeviceType == "Rotator" || DeviceType == "CAA")
+    {
+        dpRotator = NULL;
+        if (systemdevicelist.system_devices.size() > 24)
+        {
+            disconnectdriverName = systemdevicelist.system_devices[24].DriverIndiName;
+            systemdevicelist.system_devices[24].isConnect = false;
+            systemdevicelist.system_devices[24].isBind = false;
+            systemdevicelist.system_devices[24].DeviceIndiName = "";
+            systemdevicelist.system_devices[24].DeviceIndiGroup = -1;
+            systemdevicelist.system_devices[24].dp = NULL;
+        }
     }
 
     QStringList SelectedCameras;

--- a/src/mainwindow_device_connection.cpp
+++ b/src/mainwindow_device_connection.cpp
@@ -2780,6 +2780,25 @@ void MainWindow::UnBindingDevice(QString DeviceType)
                 sdkMainCfwSlotsCached = 0;
                 emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:CFW");
             }
+            if (isCAAOnCamera)
+            {
+                isCAAOnCamera = false;
+                sdkCAAHandle = nullptr;
+                sdkMainCaaInfoCached = SdkControlParamInfo{};
+                sdkCaaAccumulatedOffset = 0.0;
+                SdkManager::instance().unregisterDevice("Rotator");
+                if (systemdevicelist.system_devices.size() > 24)
+                {
+                    systemdevicelist.system_devices[24].Description.clear();
+                    systemdevicelist.system_devices[24].DriverIndiName.clear();
+                    systemdevicelist.system_devices[24].SDKDriverName.clear();
+                    systemdevicelist.system_devices[24].DriverFrom.clear();
+                    systemdevicelist.system_devices[24].isSDKConnect = false;
+                    systemdevicelist.system_devices[24].isConnect = false;
+                    systemdevicelist.system_devices[24].isBind = false;
+                }
+                emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:Rotator");
+            }
 
             // 解除绑定：仅清理角色绑定，不关闭句柄池（保持待分配列表可用）
             systemdevicelist.system_devices[20].isBind = false;
@@ -3058,8 +3077,13 @@ void MainWindow::AfterDeviceConnect(INDI::BaseDevice *dp)
             // ==================== SDK 主相机初始化流程 ====================
             // 记录“上一轮是否为相机内置 CFW”，用于在本轮未检测到 CFW 时清理前端残留状态
             const bool prevFilterOnCamera = isFilterOnCamera;
+            const bool prevCAAOnCamera = isCAAOnCamera;
             isFilterOnCamera = false;
+            isCAAOnCamera = false;
             sdkMainCfwSlotsCached = 0;
+            sdkCAAHandle = nullptr;
+            sdkMainCaaInfoCached = SdkControlParamInfo{};
+            sdkCaaAccumulatedOffset = 0.0;
 
             // 0. 读取本地保存的主相机参数（config/config.ini）
             // 注意：INDI 分支在 dpMainCamera == dp 时会调用 getMainCameraParameters() 并设置初始参数；
@@ -3560,6 +3584,84 @@ void MainWindow::AfterDeviceConnect(INDI::BaseDevice *dp)
             if (!isFilterOnCamera && prevFilterOnCamera)
             {
                 emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:CFW");
+            }
+
+            // ==================== SDK 模式下探测“相机内置 CAA 旋转器” ====================
+            {
+                SdkCommand caaAvailableCmd;
+                caaAvailableCmd.type = SdkCommandType::Custom;
+                caaAvailableCmd.name = "IsCAARotatorAvailable";
+                caaAvailableCmd.payload = std::any();
+                SdkResult caaAvailableRes = sdkCallMain(caaAvailableCmd);
+                bool caaAvailable = false;
+                if (caaAvailableRes.success && caaAvailableRes.payload.has_value())
+                {
+                    try { caaAvailable = std::any_cast<bool>(caaAvailableRes.payload); } catch (const std::bad_any_cast&) { caaAvailable = false; }
+                }
+
+                if (caaAvailable)
+                {
+                    SdkControlParamInfo caaInfo;
+                    std::string err;
+                    if (sdkGetCaaRotator(sdkMainCameraHandle, caaInfo, &err))
+                    {
+                        isCAAOnCamera = true;
+                        sdkCAAHandle = sdkMainCameraHandle;
+                        sdkMainCaaInfoCached = caaInfo;
+                        sdkCaaAccumulatedOffset = 0.0;
+
+                        QString caaDriverName = getSDKDriverName("MainCamera");
+                        if (!caaDriverName.isEmpty())
+                        {
+                            SdkResult caaRegRes = SdkManager::instance().registerDevice(
+                                caaDriverName.toStdString(),
+                                "Rotator",
+                                sdkCAAHandle,
+                                "CAA Rotator",
+                                std::any(sdkMainCameraId.toStdString()));
+                            if (!caaRegRes.success)
+                            {
+                                Logger::Log("AfterDeviceConnect | Failed to register CAA Rotator to SdkManager: " + caaRegRes.message,
+                                            LogLevel::WARNING, DeviceType::CAMERA);
+                            }
+                        }
+
+                        if (systemdevicelist.system_devices.size() > 24)
+                        {
+                            systemdevicelist.system_devices[24].Description = "Rotator";
+                            systemdevicelist.system_devices[24].DriverIndiName = systemdevicelist.system_devices[20].DriverIndiName;
+                            systemdevicelist.system_devices[24].SDKDriverName = systemdevicelist.system_devices[20].SDKDriverName;
+                            systemdevicelist.system_devices[24].DriverFrom = "SDK";
+                            systemdevicelist.system_devices[24].DeviceIndiName = sdkCaaDisplayName(sdkMainCameraId);
+                            systemdevicelist.system_devices[24].isSDKConnect = true;
+                            systemdevicelist.system_devices[24].isConnect = true;
+                            systemdevicelist.system_devices[24].isBind = true;
+                        }
+
+                        const QString caaDisplayName = sdkCaaDisplayName(sdkMainCameraId);
+                        Logger::Log("AfterDeviceConnect | SDK CAA detected, angle=" + std::to_string(caaInfo.current),
+                                    LogLevel::INFO, DeviceType::CAMERA);
+                        emit wsThread->sendMessageToClient("ConnectSuccess:Rotator:" + caaDisplayName + ":" + QString::fromLatin1("indi_qhy_ccd"));
+                        emit wsThread->sendMessageToClient(
+                            "CAARotatorRange:" +
+                            QString::number(caaInfo.minValue, 'f', 2) + ":" +
+                            QString::number(caaInfo.maxValue, 'f', 2) + ":" +
+                            QString::number(caaInfo.step, 'f', 2) + ":" +
+                            QString::number(caaInfo.current, 'f', 2));
+                        emit wsThread->sendMessageToClient("CAARotatorAngle:" + QString::number(caaInfo.current, 'f', 2));
+                        emit wsThread->sendMessageToClient("CAARotatorAccumulatedOffset:" + QString::number(sdkCaaAccumulatedOffset, 'f', 2));
+                    }
+                    else
+                    {
+                        Logger::Log("AfterDeviceConnect | SDK CAA available but GetCAARotator failed: " + err,
+                                    LogLevel::WARNING, DeviceType::CAMERA);
+                    }
+                }
+            }
+
+            if (!isCAAOnCamera && prevCAAOnCamera)
+            {
+                emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:Rotator");
             }
             
             Logger::Log("AfterDeviceConnect | SDK MainCamera initialization completed", 
@@ -8848,6 +8950,26 @@ void MainWindow::DisconnectDevice(MyClient *client, QString DeviceName, QString 
                 if (wsThread != nullptr)
                     emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:CFW");
             }
+            if (isCAAOnCamera)
+            {
+                isCAAOnCamera = false;
+                sdkCAAHandle = nullptr;
+                sdkMainCaaInfoCached = SdkControlParamInfo{};
+                sdkCaaAccumulatedOffset = 0.0;
+                SdkManager::instance().unregisterDevice("Rotator");
+                if (systemdevicelist.system_devices.size() > 24)
+                {
+                    systemdevicelist.system_devices[24].Description.clear();
+                    systemdevicelist.system_devices[24].DriverIndiName.clear();
+                    systemdevicelist.system_devices[24].SDKDriverName.clear();
+                    systemdevicelist.system_devices[24].DriverFrom.clear();
+                    systemdevicelist.system_devices[24].isSDKConnect = false;
+                    systemdevicelist.system_devices[24].isConnect = false;
+                    systemdevicelist.system_devices[24].isBind = false;
+                }
+                if (wsThread != nullptr)
+                    emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:Rotator");
+            }
 
             // 2) 关闭当前绑定的 MainCamera 句柄（若存在）
             QString closedCameraId;
@@ -9215,6 +9337,26 @@ void MainWindow::DisconnectDevice(MyClient *client, QString DeviceName, QString 
                     sdkMainCfwSlotsCached = 0;
                     if (wsThread != nullptr)
                         emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:CFW");
+                }
+                if (DeviceType == "MainCamera" && isCAAOnCamera)
+                {
+                    isCAAOnCamera = false;
+                    sdkCAAHandle = nullptr;
+                    sdkMainCaaInfoCached = SdkControlParamInfo{};
+                    sdkCaaAccumulatedOffset = 0.0;
+                    SdkManager::instance().unregisterDevice("Rotator");
+                    if (systemdevicelist.system_devices.size() > 24)
+                    {
+                        systemdevicelist.system_devices[24].Description.clear();
+                        systemdevicelist.system_devices[24].DriverIndiName.clear();
+                        systemdevicelist.system_devices[24].SDKDriverName.clear();
+                        systemdevicelist.system_devices[24].DriverFrom.clear();
+                        systemdevicelist.system_devices[24].isSDKConnect = false;
+                        systemdevicelist.system_devices[24].isConnect = false;
+                        systemdevicelist.system_devices[24].isBind = false;
+                    }
+                    if (wsThread != nullptr)
+                        emit wsThread->sendMessageToClient("deleteDeviceTypeAllocationList:Rotator");
                 }
 
                 if (wsThread != nullptr)

--- a/src/myclient.cpp
+++ b/src/myclient.cpp
@@ -41,7 +41,7 @@ void MyClient::newMessage(INDI::BaseDevice baseDevice, int messageID)
 {
     // qDebug("[INDI SERVER] %s", baseDevice.messageQueue(messageID).c_str());
 
-    std::string message = baseDevice->messageQueue(messageID);
+    std::string message = baseDevice.messageQueue(messageID);
     receiveMessage(message);
 }
 
@@ -50,7 +50,7 @@ void MyClient::newProperty(INDI::Property property)
     // if (!baseDevice.isDeviceNameMatch("Simple CCD"))
     //    return;
 
-    // qDebug() << "newProperty: " << property->getName();
+    // qDebug() << "newProperty: " << property.getName();
     // qDebug("Recveing message from Server %s", baseDevice.messageQueue(messageID).c_str());
 }
 
@@ -135,7 +135,7 @@ void MyClient::updateProperty(INDI::Property property)
 
 //************************ device list management***********************************
 
-void MyClient::AddDevice(INDI::BaseDevice *device, const std::string &name)
+void MyClient::AddDevice(const INDI::BaseDevice &device, const std::string &name)
 {
     // 修复：确保deviceList和deviceNames保持同步
     // 检查两个列表的大小是否一致
@@ -160,14 +160,14 @@ void MyClient::AddDevice(INDI::BaseDevice *device, const std::string &name)
             else
             {
                 // 如果设备没有连接，替换这个设备
-                deviceList[i] = device;
+                deviceList[i] = std::make_shared<INDI::BaseDevice>(device);
                 return;
             }
         }
     }
     // 如果没有找到同名的设备，添加新设备
     // 确保同时添加到两个列表，保持同步
-    deviceList.push_back(device);
+    deviceList.push_back(std::make_shared<INDI::BaseDevice>(device));
     deviceNames.push_back(name);
     Logger::Log("indi_client | newDevice | New DeviceName:" + std::string(name) + ", GetDeviceCount:" + std::to_string(GetDeviceCount()), LogLevel::INFO, DeviceType::MAIN);
 }
@@ -257,7 +257,7 @@ INDI::BaseDevice *MyClient::GetDeviceFromList(int index)
     {
         return nullptr;
     }
-    return deviceList[index];
+    return deviceList[index].get();
 }
 
 INDI::BaseDevice *MyClient::GetDeviceFromListWithName(std::string devName)
@@ -266,7 +266,7 @@ INDI::BaseDevice *MyClient::GetDeviceFromListWithName(std::string devName)
     for (int i = 0; i < deviceList.size(); i++)
     {
         if (deviceNames[i] == devName)
-            return deviceList[i];
+            return deviceList[i].get();
     }
 
     // if not found return null
@@ -322,15 +322,11 @@ void MyClient::disconnectAllDevice(void)
 // need to wait the connection completely finished then call this , otherwise it may not output all
 void MyClient::listAllProperties(INDI::BaseDevice *dp)
 {
-    std::vector<INDI::Property> properties(dp->getProperties().begin(), dp->getProperties().end());
-
-    // Iterate over the list of properties and print the names of the PropertyNumber properties
-    for (INDI::Property *property : properties)
+    for (const auto &property : dp->getProperties())
     {
-        // INDI::PropertyNumber *numberProperty = static_cast<INDI::PropertyNumber *>(property);
-        if (property != nullptr)
+        if (property.isValid())
         {
-            std::cout << property->getName() << std::endl;
+            std::cout << property.getName() << std::endl;
         }
     }
 }
@@ -340,8 +336,8 @@ void MyClient::GetAllPropertyName(INDI::BaseDevice *dp)
     // 直接使用范围for循环遍历属性
     for (const auto &property : dp->getProperties())
     {
-        const char *propertyName = property->getName();
-        const char *propertyType = PropertyTypeToString(property->getType());
+        const char *propertyName = property.getName();
+        const char *propertyType = PropertyTypeToString(property.getType());
         // 在此处处理属性
         // propertyName 包含了属性的名称
         Logger::Log("indi_client | GetAllPropertyName | " + std::string(propertyName) + ", " + std::string(propertyType), LogLevel::INFO, DeviceType::MAIN);
@@ -473,7 +469,9 @@ uint32_t MyClient::getTemperature(INDI::BaseDevice *dp, double &value)
 
     // qDebug("getting temperature  %g C.", value);
 
-    value = ccdTemperature->np[0].value;
+    if (ccdTemperature.size() < 1)
+        return QHYCCD_ERROR;
+    value = ccdTemperature[0].getValue();
 
     return QHYCCD_SUCCESS;
 }
@@ -628,8 +626,8 @@ uint32_t MyClient::takeExposure(INDI::BaseDevice *dp, double seconds)
         for (const auto &p : dp->getProperties())
         {
             if (!p) continue;
-            if (p->getType() != INDI_NUMBER) continue;
-            std::string pn = p->getName() ? std::string(p->getName()) : std::string();
+            if (p.getType() != INDI_NUMBER) continue;
+            std::string pn = p.getName() ? std::string(p.getName()) : std::string();
             std::string pnUpper = pn;
             std::transform(pnUpper.begin(), pnUpper.end(), pnUpper.begin(),
                            [](unsigned char c){ return std::toupper(c); });
@@ -680,10 +678,12 @@ uint32_t MyClient::getCCDFrameInfo(INDI::BaseDevice *dp, int &X, int &Y, int &WI
         return QHYCCD_ERROR;
     }
 
-    X = ccdFrameInfo->np[0].value;
-    Y = ccdFrameInfo->np[1].value;
-    WIDTH = ccdFrameInfo->np[2].value;
-    HEIGHT = ccdFrameInfo->np[3].value;
+    if (ccdFrameInfo.size() < 4)
+        return QHYCCD_ERROR;
+    X = ccdFrameInfo[0].getValue();
+    Y = ccdFrameInfo[1].getValue();
+    WIDTH = ccdFrameInfo[2].getValue();
+    HEIGHT = ccdFrameInfo[3].getValue();
 
     Logger::Log("indi_client | getCCDFrameInfo | " + std::to_string(X) + ", " + std::to_string(Y) + ", " + std::to_string(WIDTH) + ", " + std::to_string(HEIGHT), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
@@ -777,12 +777,14 @@ uint32_t MyClient::getCCDBasicInfo(INDI::BaseDevice *dp, int &maxX, int &maxY, d
         return QHYCCD_ERROR;
     }
 
-    maxX = ccdInfo->np[0].value;
-    maxY = ccdInfo->np[1].value;
-    pixelsize = ccdInfo->np[2].value;
-    pixelsizX = ccdInfo->np[3].value;
-    pixelsizY = ccdInfo->np[4].value;
-    bitDepth = ccdInfo->np[5].value;
+    if (ccdInfo.size() < 6)
+        return QHYCCD_ERROR;
+    maxX = ccdInfo[0].getValue();
+    maxY = ccdInfo[1].getValue();
+    pixelsize = ccdInfo[2].getValue();
+    pixelsizX = ccdInfo[3].getValue();
+    pixelsizY = ccdInfo[4].getValue();
+    bitDepth = ccdInfo[5].getValue();
     Logger::Log("indi_client | getCCDBasicInfo | " + std::to_string(maxX) + ", " + std::to_string(maxY) + ", " + std::to_string(pixelsize) + ", " + std::to_string(pixelsizX) + ", " + std::to_string(pixelsizY) + ", " + std::to_string(bitDepth), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
 }
@@ -797,12 +799,14 @@ uint32_t MyClient::setCCDBasicInfo(INDI::BaseDevice *dp, int maxX, int maxY, dou
         return QHYCCD_ERROR;
     }
 
-    ccdInfo->np[0].value = maxX;
-    ccdInfo->np[1].value = maxY;
-    ccdInfo->np[2].value = pixelsize;
-    ccdInfo->np[3].value = pixelsizX;
-    ccdInfo->np[4].value = pixelsizY;
-    ccdInfo->np[5].value = bitDepth;
+    if (ccdInfo.size() < 6)
+        return QHYCCD_ERROR;
+    ccdInfo[0].setValue(maxX);
+    ccdInfo[1].setValue(maxY);
+    ccdInfo[2].setValue(pixelsize);
+    ccdInfo[3].setValue(pixelsizX);
+    ccdInfo[4].setValue(pixelsizY);
+    ccdInfo[5].setValue(bitDepth);
     Logger::Log("indi_client | setCCDBasicInfo | " + std::to_string(maxX) + ", " + std::to_string(maxY) + ", " + std::to_string(pixelsize) + ", " + std::to_string(pixelsizX) + ", " + std::to_string(pixelsizY) + ", " + std::to_string(bitDepth), LogLevel::INFO, DeviceType::CAMERA);
 
     sendNewProperty(ccdInfo);
@@ -820,10 +824,12 @@ uint32_t MyClient::getCCDBinning(INDI::BaseDevice *dp, int &BINX, int &BINY, int
         return QHYCCD_ERROR;
     }
 
-    BINX = ccdbinning->np[0].value;
-    BINY = ccdbinning->np[1].value;
-    BINXMAX = ccdbinning->np[0].max;
-    BINYMAX = ccdbinning->np[1].max;
+    if (ccdbinning.size() < 2)
+        return QHYCCD_ERROR;
+    BINX = ccdbinning[0].getValue();
+    BINY = ccdbinning[1].getValue();
+    BINXMAX = ccdbinning[0].getMax();
+    BINYMAX = ccdbinning[1].getMax();
 
     Logger::Log("indi_client | getCCDBinning | " + std::to_string(BINX) + ", " + std::to_string(BINY) + ", " + std::to_string(BINXMAX) + ", " + std::to_string(BINYMAX), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
@@ -1100,10 +1106,12 @@ uint32_t MyClient::getCCDUsbTraffic(INDI::BaseDevice *dp, int &value, int &min, 
         return QHYCCD_ERROR;
     }
 
-    value = static_cast<int>(usbTraffic->np[0].value);
-    min = static_cast<int>(usbTraffic->np[0].min);
-    max = static_cast<int>(usbTraffic->np[0].max);
-    step = static_cast<int>(usbTraffic->np[0].step);
+    if (usbTraffic.size() < 1)
+        return QHYCCD_ERROR;
+    value = static_cast<int>(usbTraffic[0].getValue());
+    min = static_cast<int>(usbTraffic[0].getMin());
+    max = static_cast<int>(usbTraffic[0].getMax());
+    step = static_cast<int>(usbTraffic[0].getStep());
     if (step <= 0) step = 1;
 
     Logger::Log("indi_client | getCCDUsbTraffic | " + std::to_string(value) + ", " + std::to_string(min) + ", " + std::to_string(max) + ", step " + std::to_string(step),
@@ -1137,9 +1145,11 @@ uint32_t MyClient::getCCDReadMode(INDI::BaseDevice *dp, int &value, int &min, in
         return QHYCCD_ERROR;
     }
 
-    value = ccdreadmode->np[0].value;
-    min = ccdreadmode->np[0].min;
-    max = ccdreadmode->np[0].max;
+    if (ccdreadmode.size() < 1)
+        return QHYCCD_ERROR;
+    value = ccdreadmode[0].getValue();
+    min = ccdreadmode[0].getMin();
+    max = ccdreadmode[0].getMax();
 
     Logger::Log("indi_client | getCCDReadMode | " + std::to_string(value) + ", " + std::to_string(min) + ", " + std::to_string(max), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
@@ -1274,7 +1284,7 @@ uint32_t MyClient::getMountInfo(INDI::BaseDevice *dp, QString &version)
     }
 
     INDI::PropertyText mountInfo = dp->getProperty("DRIVER_INFO");
-    if (!mountInfo.isValid() || mountInfo->ntp <= 0)
+    if (!mountInfo.isValid() || mountInfo.size() <= 0)
     {
         Logger::Log("indi_client | getMountInfo | Error: unable to find DRIVER_INFO or empty", LogLevel::WARNING, DeviceType::MOUNT);
         return QHYCCD_ERROR;
@@ -1283,10 +1293,10 @@ uint32_t MyClient::getMountInfo(INDI::BaseDevice *dp, QString &version)
     int chosenIdx = -1; // 用于提取版本项
     // 附加字段：便于注释式打印
     std::string drvName, drvExec, drvVersion, drvInterface;
-    for (int i = 0; i < mountInfo->ntp; i++)
+    for (int i = 0; i < mountInfo.size(); i++)
     {
-        const char *name = mountInfo->tp[i].name;
-        const char *text = mountInfo->tp[i].text;
+        const char *name = mountInfo[i].getName();
+        const char *text = mountInfo[i].getText();
 
         // std::ostringstream oss;
         // oss << "indi_client | getMountInfo | DRIVER_INFO"
@@ -1297,7 +1307,7 @@ uint32_t MyClient::getMountInfo(INDI::BaseDevice *dp, QString &version)
         //     << " group:" << (mountInfo->group ? mountInfo->group : "")
         //     << " perm:" << static_cast<int>(mountInfo->p)
         //     << " state:" << static_cast<int>(mountInfo->s)
-        //     << " ntp:" << mountInfo->ntp;
+        //     << " ntp:" << mountInfo.size();
         // Logger::Log(oss.str(), LogLevel::INFO, DeviceType::MOUNT);
 
         if (chosenIdx == -1 && name)
@@ -1323,7 +1333,7 @@ uint32_t MyClient::getMountInfo(INDI::BaseDevice *dp, QString &version)
     }
 
     if (chosenIdx >= 0)
-        version = QString::fromUtf8(mountInfo->tp[chosenIdx].text ? mountInfo->tp[chosenIdx].text : "");
+        version = QString::fromUtf8(mountInfo[chosenIdx].getText() ? mountInfo[chosenIdx].getText() : "");
     else
         version.clear();
 
@@ -1567,10 +1577,12 @@ uint32_t MyClient::getTelescopeInfo(INDI::BaseDevice *dp, double &telescope_aper
         return QHYCCD_ERROR;
     }
 
-    telescope_aperture = property->np[0].value;
-    telescope_focal = property->np[1].value;
-    guider_aperature = property->np[2].value;
-    guider_focal = property->np[3].value;
+    if (property.size() < 4)
+        return QHYCCD_ERROR;
+    telescope_aperture = property[0].getValue();
+    telescope_focal = property[1].getValue();
+    guider_aperature = property[2].getValue();
+    guider_focal = property[3].getValue();
     Logger::Log("indi_client | getTelescopeInfo | " + std::to_string(telescope_aperture) + ", " + std::to_string(telescope_focal) + ", " + std::to_string(guider_aperature) + ", " + std::to_string(guider_focal), LogLevel::INFO, DeviceType::MOUNT);
     return QHYCCD_SUCCESS;
 }
@@ -1776,8 +1788,10 @@ uint32_t MyClient::getTelescopeParkPosition(INDI::BaseDevice *dp, double &RA_DEG
         return QHYCCD_ERROR;
     }
 
-    RA_DEGREE = property->np[0].value;
-    DEC_DEGREE = property->np[1].value;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    RA_DEGREE = property[0].getValue();
+    DEC_DEGREE = property[1].getValue();
     Logger::Log("indi_client | getTelescopeParkPosition | " + std::to_string(RA_DEGREE) + ", " + std::to_string(DEC_DEGREE), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
 }
@@ -1794,8 +1808,10 @@ uint32_t MyClient::setTelescopeParkPosition(INDI::BaseDevice *dp, double RA_DEGR
         return QHYCCD_ERROR;
     }
 
-    property->np[0].value = RA_DEGREE;
-    property->np[1].value = DEC_DEGREE;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    property[0].setValue(RA_DEGREE);
+    property[1].setValue(DEC_DEGREE);
 
     sendNewProperty(property);
     Logger::Log("indi_client | setTelescopeParkPosition | " + std::to_string(RA_DEGREE) + ", " + std::to_string(DEC_DEGREE), LogLevel::INFO, DeviceType::CAMERA);
@@ -1886,7 +1902,7 @@ uint32_t MyClient::setTelescopeHomeInit(INDI::BaseDevice *dp, QString command)
         }
 
         // 先全部关
-        for (int i = 0; i < prop->nsp; ++i)
+        for (int i = 0; i < prop.size(); ++i)
             prop[i].setState(ISS_OFF);
 
         if (command == "SLEWHOME" || command == "RETURN_HOME")
@@ -2183,9 +2199,11 @@ uint32_t MyClient::getTelescopeMaxSlewRateOptions(INDI::BaseDevice *dp, int &min
         return QHYCCD_ERROR;
     }
 
-    max = property->np[0].max;
-    min = property->np[0].min;
-    value = property->np[0].value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    max = property[0].getMax();
+    min = property[0].getMin();
+    value = property[0].getValue();
 
     Logger::Log("indi_client | getTelescopeMaxSlewRateOptions" + std::to_string(max) + " " + std::to_string(min) + " " + std::to_string(value), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
@@ -2202,13 +2220,15 @@ uint32_t MyClient::setTelescopeMaxSlewRateOptions(INDI::BaseDevice *dp, int valu
         return QHYCCD_ERROR;
     }
 
-    property->np[0].value = value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    property[0].setValue(value);
     sendNewProperty(property);
 
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }
@@ -2421,7 +2441,7 @@ uint32_t MyClient::setTelescopeGuideNS(INDI::BaseDevice *dp, int dir, int time_g
 
     const std::string deviceName = dp && dp->getDeviceName() ? dp->getDeviceName() : "UNKNOWN";
     const char *stateName = "UNKNOWN";
-    switch (property->getState())
+    switch (property.getState())
     {
     case IPS_IDLE: stateName = "IDLE"; break;
     case IPS_OK: stateName = "OK"; break;
@@ -2432,21 +2452,21 @@ uint32_t MyClient::setTelescopeGuideNS(INDI::BaseDevice *dp, int dir, int time_g
 
     if (dir == 1)
     {
-        property->np[1].value = time_guide;
-        property->np[0].value = 0;
+        property[1].setValue(time_guide);
+        property[0].setValue(0);
         mountState.isGuiding = true;
     }
     else
     {
-        property->np[0].value = time_guide;
-        property->np[1].value = 0;
+        property[0].setValue(time_guide);
+        property[1].setValue(0);
         mountState.isGuiding = false;
     }
     Logger::Log("indi_client | setTelescopeGuideNS | dev=" + deviceName +
                     " dir=" + std::to_string(dir) +
                     " durationMs=" + std::to_string(time_guide) +
-                    " | S=" + std::to_string(static_cast<int>(property->np[0].value)) +
-                    " N=" + std::to_string(static_cast<int>(property->np[1].value)) +
+                    " | S=" + std::to_string(static_cast<int>(property[0].getValue())) +
+                    " N=" + std::to_string(static_cast<int>(property[1].getValue())) +
                     " stateBefore=" + stateName,
                 LogLevel::INFO, DeviceType::MOUNT);
     sendNewProperty(property);
@@ -2464,7 +2484,7 @@ uint32_t MyClient::setTelescopeGuideWE(INDI::BaseDevice *dp, int dir, int time_g
 
     const std::string deviceName = dp && dp->getDeviceName() ? dp->getDeviceName() : "UNKNOWN";
     const char *stateName = "UNKNOWN";
-    switch (property->getState())
+    switch (property.getState())
     {
     case IPS_IDLE: stateName = "IDLE"; break;
     case IPS_OK: stateName = "OK"; break;
@@ -2475,21 +2495,21 @@ uint32_t MyClient::setTelescopeGuideWE(INDI::BaseDevice *dp, int dir, int time_g
 
     if (dir == 3)
     {
-        property->np[0].value = time_guide;
-        property->np[1].value = 0;
+        property[0].setValue(time_guide);
+        property[1].setValue(0);
         mountState.isGuiding = true;
     }
     else
     {
-        property->np[1].value = time_guide;
-        property->np[0].value = 0;
+        property[1].setValue(time_guide);
+        property[0].setValue(0);
         mountState.isGuiding = false;
     }
     Logger::Log("indi_client | setTelescopeGuideWE | dev=" + deviceName +
                     " dir=" + std::to_string(dir) +
                     " durationMs=" + std::to_string(time_guide) +
-                    " | W=" + std::to_string(static_cast<int>(property->np[0].value)) +
-                    " E=" + std::to_string(static_cast<int>(property->np[1].value)) +
+                    " | W=" + std::to_string(static_cast<int>(property[0].getValue())) +
+                    " E=" + std::to_string(static_cast<int>(property[1].getValue())) +
                     " stateBefore=" + stateName,
                 LogLevel::INFO, DeviceType::MOUNT);
     sendNewProperty(property);
@@ -2626,7 +2646,7 @@ uint32_t MyClient::setTelescopeActionAfterPositionSet(INDI::BaseDevice *dp, QStr
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }
@@ -2651,8 +2671,10 @@ uint32_t MyClient::getTelescopeRADECJ2000(INDI::BaseDevice *dp, double &RA_Hours
         return QHYCCD_ERROR;
     }
 
-    RA_Hours = property->np[0].value;
-    DEC_Degree = property->np[1].value;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    RA_Hours = property[0].getValue();
+    DEC_Degree = property[1].getValue();
     Logger::Log("indi_client | getTelescopeRADECJ2000" + std::to_string(RA_Hours) + " " + std::to_string(DEC_Degree), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
 }
@@ -2669,8 +2691,10 @@ uint32_t MyClient::setTelescopeRADECJ2000(INDI::BaseDevice *dp, double RA_Hours,
         return QHYCCD_ERROR;
     }
 
-    property->np[0].value = RA_Hours;
-    property->np[1].value = DEC_Degree;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    property[0].setValue(RA_Hours);
+    property[1].setValue(DEC_Degree);
 
     sendNewProperty(property);
     // qDebug()<<"setTelescopeRADECJ2000"<< value;
@@ -2687,8 +2711,10 @@ uint32_t MyClient::getTelescopeRADECJNOW(INDI::BaseDevice *dp, double &RA_Hours,
         Logger::Log("indi_client | getTelescopeRADECJNOW | Error: unable to find  EQUATORIAL_EOD_COORD property...", LogLevel::WARNING, DeviceType::CAMERA);
         return QHYCCD_ERROR;
     }
-    RA_Hours = property->np[0].value;
-    DEC_Degree = property->np[1].value;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    RA_Hours = property[0].getValue();
+    DEC_Degree = property[1].getValue();
     // qDebug() << "getTelescopeRADECJNOW" << RA_Hours << DEC_Degree ;
     return QHYCCD_SUCCESS;
 }
@@ -2703,8 +2729,8 @@ uint32_t MyClient::getTelescopeRADECJNOW(INDI::BaseDevice *dp, double &RA_Hours,
 //         return QHYCCD_ERROR;
 //     }
 
-//     property->np[0].value=RA_Hours;
-//     property->np[1].value=DEC_Degree;
+//     .setValue(RA_Hours);
+//     .setValue(DEC_Degree);
 
 //     sendNewProperty(property);
 
@@ -2748,8 +2774,8 @@ uint32_t MyClient::setTelescopeRADECJNOW(INDI::BaseDevice *dp, double RA_Hours, 
         return QHYCCD_ERROR;
     }
 
-    property->np[0].value = RA_Hours;
-    property->np[1].value = DEC_Degree;
+    property[0].setValue(RA_Hours);
+    property[1].setValue(DEC_Degree);
     sendNewProperty(property);
 
     if (currentAction == "SYNC")
@@ -2868,8 +2894,10 @@ uint32_t MyClient::getTelescopeTargetRADECJNOW(INDI::BaseDevice *dp, double &RA_
         return QHYCCD_ERROR;
     }
 
-    RA_Hours = property->np[0].value;
-    DEC_Degree = property->np[1].value;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    RA_Hours = property[0].getValue();
+    DEC_Degree = property[1].getValue();
     Logger::Log("indi_client | getTelescopeTargetRADECJNOW" + std::to_string(RA_Hours) + " " + std::to_string(DEC_Degree), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
 }
@@ -2887,8 +2915,10 @@ uint32_t MyClient::setTelescopeTargetRADECJNOW(INDI::BaseDevice *dp, double RA_H
         return QHYCCD_ERROR;
     }
 
-    property->np[0].value = RA_Hours;
-    property->np[1].value = DEC_Degree;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    property[0].setValue(RA_Hours);
+    property[1].setValue(DEC_Degree);
 
     sendNewProperty(property);
     // qDebug()<<"setTelescopeTargetRADECJNOW"<< value;
@@ -2967,8 +2997,10 @@ uint32_t MyClient::getTelescopetAZALT(INDI::BaseDevice *dp, double &AZ_DEGREE, d
         return QHYCCD_ERROR;
     }
 
-    ALT_DEGREE = property->np[0].value;
-    AZ_DEGREE = property->np[1].value;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    ALT_DEGREE = property[0].getValue();
+    AZ_DEGREE = property[1].getValue();
     Logger::Log("indi_client | getTelescopetAZALT" + std::to_string(AZ_DEGREE) + " " + std::to_string(ALT_DEGREE), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
 }
@@ -2984,8 +3016,10 @@ uint32_t MyClient::setTelescopetAZALT(INDI::BaseDevice *dp, double AZ_DEGREE, do
         Logger::Log("indi_client | setTelescopetAZALT | Error: unable to find  HORIZONTAL_COORD property...", LogLevel::WARNING, DeviceType::CAMERA);
         return QHYCCD_ERROR;
     }
-    property->np[0].value = AZ_DEGREE;
-    property->np[1].value = ALT_DEGREE;
+    if (property.size() < 2)
+        return QHYCCD_ERROR;
+    property[0].setValue(AZ_DEGREE);
+    property[1].setValue(ALT_DEGREE);
 
     sendNewProperty(property);
     // qDebug()<<"setTelescopetAZALT"<< AZ_DEGREE <<ALT_DEGREE;
@@ -3185,7 +3219,7 @@ uint32_t MyClient::getFocuserSDKVersion(INDI::BaseDevice *dp, QString &version)
     }
 
     INDI::PropertyNumber focuserSDKVersion = dp->getProperty("FOCUS_VERSION");
-    if (!focuserSDKVersion.isValid() || focuserSDKVersion->nnp <= 0)
+    if (!focuserSDKVersion.isValid() || focuserSDKVersion.size() <= 0)
     {
         Logger::Log("indi_client | getFocuserSDKVersion | Error: unable to find  FOCUS_VERSION property...", LogLevel::WARNING, DeviceType::FOCUSER);
         return QHYCCD_ERROR;
@@ -3193,9 +3227,9 @@ uint32_t MyClient::getFocuserSDKVersion(INDI::BaseDevice *dp, QString &version)
 
     // 选择条目：优先 name 含 "VERSION" 的项，否则使用第 0 项
     int idx = 0;
-    for (int i = 0; i < focuserSDKVersion->nnp; i++)
+    for (int i = 0; i < focuserSDKVersion.size(); i++)
     {
-        const char *nm = focuserSDKVersion->np[i].name;
+        const char *nm = focuserSDKVersion[i].getName();
         if (nm && std::string(nm).find("VERSION") != std::string::npos)
         {
             idx = i;
@@ -3204,7 +3238,7 @@ uint32_t MyClient::getFocuserSDKVersion(INDI::BaseDevice *dp, QString &version)
     }
 
     // 将浮点安全地转换为整数版本号（如 20231207）
-    double v = focuserSDKVersion->np[idx].value;
+    double v = focuserSDKVersion[idx].getValue();
     uint64_t ver = static_cast<uint64_t>(std::llround(v));
     version = QString::number(static_cast<qulonglong>(ver));
 
@@ -3213,14 +3247,14 @@ uint32_t MyClient::getFocuserSDKVersion(INDI::BaseDevice *dp, QString &version)
     // oss << std::fixed << std::setprecision(0);
     // oss << "indi_client | getFocuserSDKVersion | FOCUS_VERSION"
     //     << " | choose idx:" << idx
-    //     << " name:" << (focuserSDKVersion->np[idx].name ? focuserSDKVersion->np[idx].name : "")
+    //     << " name:" << (focuserSDKVersion[idx].getName() ? focuserSDKVersion[idx].getName() : "")
     //     << " value_raw:" << v
     //     << " value_norm:" << ver
     //     << " label:" << (focuserSDKVersion->label ? focuserSDKVersion->label : "")
     //     << " group:" << (focuserSDKVersion->group ? focuserSDKVersion->group : "")
     //     << " perm:" << static_cast<int>(focuserSDKVersion->p)
     //     << " state:" << static_cast<int>(focuserSDKVersion->s)
-    //     << " nnp:" << focuserSDKVersion->nnp;
+    //     << " nnp:" << focuserSDKVersion.size();
     // Logger::Log(oss.str(), LogLevel::INFO, DeviceType::FOCUSER);
     return QHYCCD_SUCCESS;
 }
@@ -3235,10 +3269,12 @@ uint32_t MyClient::getFocuserSpeed(INDI::BaseDevice *dp, int &value, int &min, i
         return QHYCCD_ERROR;
     }
 
-    value = property->np[0].value;
-    min = property->np[0].min;
-    max = property->np[0].max;
-    step = property->np[0].step;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    value = property[0].getValue();
+    min = property[0].getMin();
+    max = property[0].getMax();
+    step = property[0].getStep();
     Logger::Log("indi_client | getFocuserSpeed" + std::to_string(value) + " " + std::to_string(min) + " " + std::to_string(max), LogLevel::INFO, DeviceType::FOCUSER);
     return QHYCCD_SUCCESS;
 }
@@ -3252,7 +3288,9 @@ uint32_t MyClient::setFocuserSpeed(INDI::BaseDevice *dp, int value)
         Logger::Log("indi_client | setFocuserSpeed | Error: unable to find  FOCUS_SPEED property...", LogLevel::WARNING, DeviceType::FOCUSER);
         return QHYCCD_ERROR;
     }
-    property->np[0].value = value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    property[0].setValue(value);
 
     sendNewProperty(property);
 
@@ -3318,7 +3356,9 @@ uint32_t MyClient::getFocuserMaxLimit(INDI::BaseDevice *dp, int &maxlimit)
         return QHYCCD_ERROR;
     }
 
-    maxlimit = property->np[0].value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    maxlimit = property[0].getValue();
 
     Logger::Log("indi_client | getFocuserMaxLimit" + std::to_string(maxlimit), LogLevel::INFO, DeviceType::FOCUSER);
     return QHYCCD_SUCCESS;
@@ -3333,7 +3373,9 @@ uint32_t MyClient::setFocuserMaxLimit(INDI::BaseDevice *dp, int maxlimit)
         Logger::Log("indi_client | setFocuserMaxLimit | Error: unable to find  FOCUS_MAX property...", LogLevel::WARNING, DeviceType::FOCUSER);
         return QHYCCD_ERROR;
     }
-    property->np[0].value = maxlimit;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    property[0].setValue(maxlimit);
 
     sendNewProperty(property);
 
@@ -3402,7 +3444,7 @@ uint32_t MyClient::moveFocuserSteps(INDI::BaseDevice *dp, int steps)
     }
     if (steps > 0)
     {
-        property->np[0].value = steps;
+        property[0].setValue(steps);
     }
     else
     {
@@ -3424,10 +3466,12 @@ uint32_t MyClient::getFocuserRange(INDI::BaseDevice *dp, int &min, int &max, int
         Logger::Log("indi_client | getFocuserRange | Error: unable to find  ABS_FOCUS_POSITION property...", LogLevel::WARNING, DeviceType::FOCUSER);
         return QHYCCD_ERROR;
     }
-    min = property->np[0].min;
-    max = property->np[0].max;
-    step = property->np[0].step;
-    value = property->np[0].value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    min = property[0].getMin();
+    max = property[0].getMax();
+    step = property[0].getStep();
+    value = property[0].getValue();
     return QHYCCD_SUCCESS;
 }
 
@@ -3440,7 +3484,9 @@ uint32_t MyClient::moveFocuserToAbsolutePosition(INDI::BaseDevice *dp, int posit
         Logger::Log("indi_client | moveFocuserToAbsolutePosition | Error: unable to find  ABS_FOCUS_POSITION property...", LogLevel::WARNING, DeviceType::FOCUSER);
         return QHYCCD_ERROR;
     }
-    property->np[0].value = position;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    property[0].setValue(position);
 
     sendNewProperty(property);
 
@@ -3458,7 +3504,9 @@ uint32_t MyClient::getFocuserAbsolutePosition(INDI::BaseDevice *dp, int &positio
         return QHYCCD_ERROR;
     }
 
-    position = property->np[0].value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    position = property[0].getValue();
 
     // sendNewProperty(property);
 
@@ -3476,7 +3524,9 @@ uint32_t MyClient::moveFocuserWithTime(INDI::BaseDevice *dp, int msec)
         Logger::Log("indi_client | moveFocuserWithTime | Error: unable to find  FOCUS_TIMER property...", LogLevel::WARNING, DeviceType::FOCUSER);
         return QHYCCD_ERROR;
     }
-    property->np[0].value = msec;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    property[0].setValue(msec);
 
     sendNewProperty(property);
 
@@ -3510,7 +3560,9 @@ uint32_t MyClient::syncFocuserPosition(INDI::BaseDevice *dp, int position)
         Logger::Log("indi_client | syncFocuserPosition | Error: unable to find  FOCUS_SYNC property...", LogLevel::WARNING, DeviceType::FOCUSER);
         return QHYCCD_ERROR;
     }
-    property->np[0].value = position;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    property[0].setValue(position);
 
     sendNewProperty(property);
 
@@ -3522,7 +3574,7 @@ uint32_t MyClient::getFocuserOutTemperature(INDI::BaseDevice *dp, double &value)
 {
     INDI::PropertyNumber property = dp->getProperty("FOCUS_TEMPERATURE");
 
-    // property->np[0].value = 0;
+    // .setValue(0);
 
     sendNewProperty(property);
 
@@ -3532,7 +3584,9 @@ uint32_t MyClient::getFocuserOutTemperature(INDI::BaseDevice *dp, double &value)
         return QHYCCD_ERROR;
     }
 
-    value = property->np[0].value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    value = property[0].getValue();
     Logger::Log("indi_client | getFocuserOutTemperature" + std::to_string(value), LogLevel::INFO, DeviceType::FOCUSER);
 
     return QHYCCD_SUCCESS;
@@ -3550,7 +3604,9 @@ uint32_t MyClient::getFocuserChipTemperature(INDI::BaseDevice *dp, double &value
         return QHYCCD_ERROR;
     }
 
-    value = property->np[0].value;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    value = property[0].getValue();
     Logger::Log("indi_client | getFocuserChipTemperature" + std::to_string(value), LogLevel::INFO, DeviceType::FOCUSER);
 
     return QHYCCD_SUCCESS;
@@ -3572,9 +3628,11 @@ uint32_t MyClient::getCFWPosition(INDI::BaseDevice *dp, int &position, int &min,
         return QHYCCD_ERROR;
     }
 
-    position = property->np[0].value;
-    min = property->np[0].min;
-    max = property->np[0].max;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    position = property[0].getValue();
+    min = property[0].getMin();
+    max = property[0].getMax();
 
     Logger::Log("indi_client | getCFWPosition" + std::to_string(position) + " " + std::to_string(min) + " " + std::to_string(max), LogLevel::INFO, DeviceType::CAMERA);
     return QHYCCD_SUCCESS;
@@ -3589,7 +3647,9 @@ uint32_t MyClient::setCFWPosition(INDI::BaseDevice *dp, int position)
         Logger::Log("indi_client | setCFWPosition | Error: unable to find  FILTER_SLOT property...", LogLevel::WARNING, DeviceType::CAMERA);
         return QHYCCD_ERROR;
     }
-    property->np[0].value = position;
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+    property[0].setValue(position);
 
     sendNewProperty(property);
 
@@ -3599,12 +3659,12 @@ uint32_t MyClient::setCFWPosition(INDI::BaseDevice *dp, int position)
     int timeout = 10000;
     while (t.elapsed() < timeout)
     {
-        Logger::Log("indi_client | setCFWPosition | State:" + std::string(property->getStateAsString()), LogLevel::DEBUG, DeviceType::CAMERA);
-        // qDebug() << "State:" << property->getState();
+        Logger::Log("indi_client | setCFWPosition | State:" + std::string(property.getStateAsString()), LogLevel::DEBUG, DeviceType::CAMERA);
+        // qDebug() << "State:" << property.getState();
         QThread::msleep(300);
-        if (property->getState() == IPS_OK)
+        if (property.getState() == IPS_OK)
         {
-            Logger::Log("indi_client | setCFWPosition | State:" + std::string(property->getStateAsString()), LogLevel::INFO, DeviceType::CAMERA);
+            Logger::Log("indi_client | setCFWPosition | State:" + std::string(property.getStateAsString()), LogLevel::INFO, DeviceType::CAMERA);
             break; // it will not wait the motor arrived
         }
     }
@@ -3731,7 +3791,7 @@ uint32_t MyClient::setTimeUTC(INDI::BaseDevice *dp, QDateTime datetime)
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }
@@ -3768,7 +3828,7 @@ uint32_t MyClient::getTimeUTC(INDI::BaseDevice *dp, QDateTime &datetime)
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }
@@ -3792,16 +3852,18 @@ uint32_t MyClient::setLocation(INDI::BaseDevice *dp, double latitude_degree, dou
         return QHYCCD_ERROR;
     }
 
-    property->np[0].value = latitude_degree;
-    property->np[1].value = longitude_degree;
-    property->np[2].value = elevation;
+    if (property.size() < 3)
+        return QHYCCD_ERROR;
+    property[0].setValue(latitude_degree);
+    property[1].setValue(longitude_degree);
+    property[2].setValue(elevation);
 
     sendNewProperty(property);
 
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }
@@ -3826,16 +3888,18 @@ uint32_t MyClient::getLocation(INDI::BaseDevice *dp, double &latitude_degree, do
         return QHYCCD_ERROR;
     }
 
-    latitude_degree = property->np[0].value; // ISO8601 string
-    longitude_degree = property->np[1].value;
-    elevation = property->np[2].value;
+    if (property.size() < 3)
+        return QHYCCD_ERROR;
+    latitude_degree = property[0].getValue(); // ISO8601 string
+    longitude_degree = property[1].getValue();
+    elevation = property[2].getValue();
 
     Logger::Log("indi_client | getLocation" + std::to_string(latitude_degree) + " " + std::to_string(longitude_degree) + " " + std::to_string(elevation), LogLevel::INFO, DeviceType::CAMERA);
 
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }
@@ -3859,16 +3923,18 @@ uint32_t MyClient::setAtmosphere(INDI::BaseDevice *dp, double temperature, doubl
         return QHYCCD_ERROR;
     }
 
-    property->np[0].value = temperature;
-    property->np[1].value = pressure;
-    property->np[2].value = humidity;
+    if (property.size() < 3)
+        return QHYCCD_ERROR;
+    property[0].setValue(temperature);
+    property[1].setValue(pressure);
+    property[2].setValue(humidity);
 
     sendNewProperty(property);
 
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }
@@ -3893,16 +3959,18 @@ uint32_t MyClient::getAtmosphere(INDI::BaseDevice *dp, double &temperature, doub
         return QHYCCD_ERROR;
     }
 
-    temperature = property->np[0].value; // ISO8601 string
-    pressure = property->np[1].value;
-    humidity = property->np[2].value;
+    if (property.size() < 3)
+        return QHYCCD_ERROR;
+    temperature = property[0].getValue(); // ISO8601 string
+    pressure = property[1].getValue();
+    humidity = property[2].getValue();
 
     Logger::Log("indi_client | getAtmosphere" + std::to_string(temperature) + " " + std::to_string(pressure) + " " + std::to_string(humidity), LogLevel::INFO, DeviceType::CAMERA);
 
     QElapsedTimer t;
     t.start();
 
-    while (property->getState() != IPS_OK && t.elapsed() < 3000)
+    while (property.getState() != IPS_OK && t.elapsed() < 3000)
     {
         QThread::msleep(100);
     }

--- a/src/myclient.cpp
+++ b/src/myclient.cpp
@@ -3694,6 +3694,168 @@ uint32_t MyClient::getCFWSlotName(INDI::BaseDevice *dp, QString &name)
     return QHYCCD_SUCCESS;
 }
 
+/**************************************************************************************
+**                                  ROTATOR / CAA API
+***************************************************************************************/
+uint32_t MyClient::getRotatorAngle(INDI::BaseDevice *dp, double &angle, double &min, double &max, double &step)
+{
+    if (!dp)
+        return QHYCCD_ERROR;
+
+    INDI::PropertyNumber property = dp->getProperty("ABS_ROTATOR_ANGLE");
+
+    if (!property.isValid())
+    {
+        Logger::Log("indi_client | getRotatorAngle | Error: unable to find ABS_ROTATOR_ANGLE property...",
+                    LogLevel::WARNING, DeviceType::MAIN);
+        angle = 0.0;
+        min = 0.0;
+        max = 0.0;
+        step = 0.0;
+        return QHYCCD_ERROR;
+    }
+
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+
+    angle = property[0].getValue();
+    min = property[0].getMin();
+    max = property[0].getMax();
+    step = property[0].getStep();
+
+    Logger::Log("indi_client | getRotatorAngle | angle=" + std::to_string(angle) +
+                    " min=" + std::to_string(min) +
+                    " max=" + std::to_string(max) +
+                    " step=" + std::to_string(step),
+                LogLevel::DEBUG, DeviceType::MAIN);
+    return QHYCCD_SUCCESS;
+}
+
+uint32_t MyClient::setRotatorAngle(INDI::BaseDevice *dp, double angle)
+{
+    if (!dp)
+        return QHYCCD_ERROR;
+
+    INDI::PropertyNumber property = dp->getProperty("ABS_ROTATOR_ANGLE");
+
+    if (!property.isValid())
+    {
+        Logger::Log("indi_client | setRotatorAngle | Error: unable to find ABS_ROTATOR_ANGLE property...",
+                    LogLevel::WARNING, DeviceType::MAIN);
+        return QHYCCD_ERROR;
+    }
+
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+
+    const double min = property[0].getMin();
+    const double max = property[0].getMax();
+    if (max > min)
+        angle = std::min(max, std::max(min, angle));
+
+    property[0].setValue(angle);
+    sendNewProperty(property);
+
+    Logger::Log("indi_client | setRotatorAngle | angle=" + std::to_string(angle),
+                LogLevel::INFO, DeviceType::MAIN);
+    return QHYCCD_SUCCESS;
+}
+
+uint32_t MyClient::abortRotatorMove(INDI::BaseDevice *dp)
+{
+    if (!dp)
+        return QHYCCD_ERROR;
+
+    INDI::PropertySwitch property = dp->getProperty("ROTATOR_ABORT_MOTION");
+
+    if (!property.isValid())
+    {
+        Logger::Log("indi_client | abortRotatorMove | Error: unable to find ROTATOR_ABORT_MOTION property...",
+                    LogLevel::WARNING, DeviceType::MAIN);
+        return QHYCCD_ERROR;
+    }
+
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+
+    property[0].setState(ISS_ON);
+    sendNewProperty(property);
+
+    Logger::Log("indi_client | abortRotatorMove", LogLevel::INFO, DeviceType::MAIN);
+    return QHYCCD_SUCCESS;
+}
+
+uint32_t MyClient::getRotatorReverse(INDI::BaseDevice *dp, bool &isReversed)
+{
+    if (!dp)
+        return QHYCCD_ERROR;
+
+    INDI::PropertySwitch property = dp->getProperty("ROTATOR_REVERSE");
+
+    if (!property.isValid())
+    {
+        Logger::Log("indi_client | getRotatorReverse | Error: unable to find ROTATOR_REVERSE property...",
+                    LogLevel::WARNING, DeviceType::MAIN);
+        return QHYCCD_ERROR;
+    }
+
+    for (size_t i = 0; i < property.size(); ++i)
+    {
+        const QString name = QString::fromUtf8(property[i].getName()).toUpper();
+        if (property[i].getState() == ISS_ON &&
+            (name.contains("ENABLED") || name.contains("ON") || name.contains("REVERSE")))
+        {
+            isReversed = true;
+            return QHYCCD_SUCCESS;
+        }
+    }
+
+    isReversed = false;
+    return QHYCCD_SUCCESS;
+}
+
+uint32_t MyClient::setRotatorReverse(INDI::BaseDevice *dp, bool isReversed)
+{
+    if (!dp)
+        return QHYCCD_ERROR;
+
+    INDI::PropertySwitch property = dp->getProperty("ROTATOR_REVERSE");
+
+    if (!property.isValid())
+    {
+        Logger::Log("indi_client | setRotatorReverse | Error: unable to find ROTATOR_REVERSE property...",
+                    LogLevel::WARNING, DeviceType::MAIN);
+        return QHYCCD_ERROR;
+    }
+
+    if (property.size() < 1)
+        return QHYCCD_ERROR;
+
+    int targetIndex = -1;
+    for (size_t i = 0; i < property.size(); ++i)
+    {
+        const QString name = QString::fromUtf8(property[i].getName()).toUpper();
+        const bool looksOn = name.contains("ENABLED") || name.contains("ON") || name.contains("REVERSE");
+        const bool looksOff = name.contains("DISABLED") || name.contains("OFF") || name.contains("NORMAL");
+        if ((isReversed && looksOn) || (!isReversed && looksOff))
+        {
+            targetIndex = static_cast<int>(i);
+            break;
+        }
+    }
+    if (targetIndex < 0)
+        targetIndex = isReversed ? 0 : std::min<int>(1, static_cast<int>(property.size()) - 1);
+
+    for (size_t i = 0; i < property.size(); ++i)
+        property[i].setState(static_cast<int>(i) == targetIndex ? ISS_ON : ISS_OFF);
+
+    sendNewProperty(property);
+
+    Logger::Log("indi_client | setRotatorReverse | reversed=" + std::to_string(isReversed),
+                LogLevel::INFO, DeviceType::MAIN);
+    return QHYCCD_SUCCESS;
+}
+
 uint32_t MyClient::setCFWSlotName(INDI::BaseDevice *dp, QString name)
 {
     INDI::PropertyText property = dp->getProperty("FILTER_NAME");

--- a/src/myclient.h
+++ b/src/myclient.h
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <functional>
+#include <memory>
 #include <QElapsedTimer>
 #include <QObject>
 #include <QTimer>
@@ -37,7 +38,7 @@ class MyClient : public INDI::BaseClient
         // uint32_t QHYCCD_SUCCESS = 1;
         // uint32_t QHYCCD_ERROR = 0;
         // 添加设备
-        void AddDevice(INDI::BaseDevice* device, const std::string& name);
+        void AddDevice(const INDI::BaseDevice& device, const std::string& name);
         // 删除设备
         void RemoveDevice(const std::string& name);
         // 获取当前设备列表的设备数
@@ -253,7 +254,7 @@ class MyClient : public INDI::BaseClient
         INDI::BaseDevice mSimpleCCD;
 
         // 存储设备的列表
-        std::vector<INDI::BaseDevice *> deviceList;
+        std::vector<std::shared_ptr<INDI::BaseDevice>> deviceList;
         // 存储设备名字的列表
         std::vector<std::string> deviceNames;
 
@@ -268,7 +269,6 @@ class MyClient : public INDI::BaseClient
 
 
 #endif // MYCLIENT_H
-
 
 
 

--- a/src/myclient.h
+++ b/src/myclient.h
@@ -158,6 +158,13 @@ class MyClient : public INDI::BaseClient
         uint32_t getCFWSlotName(INDI::BaseDevice *dp,QString & name);
         uint32_t setCFWSlotName(INDI::BaseDevice *dp,QString name);
 
+        //Rotator / CAA API (INDI standard Rotator Interface)
+        uint32_t getRotatorAngle(INDI::BaseDevice *dp,double &angle,double &min,double &max,double &step);
+        uint32_t setRotatorAngle(INDI::BaseDevice *dp,double angle);
+        uint32_t abortRotatorMove(INDI::BaseDevice *dp);
+        uint32_t getRotatorReverse(INDI::BaseDevice *dp,bool &isReversed);
+        uint32_t setRotatorReverse(INDI::BaseDevice *dp,bool isReversed);
+
 
         //Focuser API
         uint32_t getFocuserSDKVersion(INDI::BaseDevice *dp,QString &version);
@@ -269,7 +276,6 @@ class MyClient : public INDI::BaseClient
 
 
 #endif // MYCLIENT_H
-
 
 
 

--- a/src/sdks/QHYCCD/QHYCCD.cpp
+++ b/src/sdks/QHYCCD/QHYCCD.cpp
@@ -171,7 +171,12 @@ std::vector<SdkCommandInfo> QhyCameraDriver::commandList() const
         {"GetCFWPosition",               "获取当前滤镜轮位置（CONTROL_CFWPORT），返回 int（0 开始）"},
         {"SetCFWPosition",               "设置滤镜轮位置（CONTROL_CFWPORT），payload 传入 int 位置（0 开始）"},
         {"SendOrderToCFW",               "发送自定义命令到滤镜轮，payload 传入 std::string order"},
-        {"GetCFWStatus",                 "获取滤镜轮状态字符串，返回 std::string"}
+        {"GetCFWStatus",                 "获取滤镜轮状态字符串，返回 std::string"},
+#if defined(QUARCS_QHY_HAS_CONTROL_CAA_ROTATOR)
+        {"IsCAARotatorAvailable",        "检测相机是否支持 CAA 旋转器（CONTROL_CAA_ROTATOR），返回 bool"},
+        {"GetCAARotator",                "获取 CAA 旋转器角度范围/当前值（CONTROL_CAA_ROTATOR），返回 SdkControlParamInfo"},
+        {"SetCAARotator",                "设置 CAA 旋转器角度（CONTROL_CAA_ROTATOR），payload 传入 double 角度"}
+#endif
     };
 }
 
@@ -1572,6 +1577,82 @@ SdkResult QhyCameraDriver::execute(SdkDeviceHandle device, const SdkCommand& cmd
                 r.message = "GetQHYCCDCFWStatus failed, error code: " + std::to_string(ret);
             }
             return r;
+        }
+
+        // 33. 检测相机内置 CAA 旋转器能力
+        if (name == "IsCAARotatorAvailable") {
+            if (!handle) {
+                r.success = false;
+                r.message = "IsCAARotatorAvailable requires a valid device handle";
+                return r;
+            }
+#if defined(QUARCS_QHY_HAS_CONTROL_CAA_ROTATOR)
+            const unsigned int ret = IsQHYCCDControlAvailable(handle, CONTROL_CAA_ROTATOR);
+            r.success = true;
+            r.payload = (ret == QHYCCD_SUCCESS);
+            r.message = (ret == QHYCCD_SUCCESS) ? "CAA rotator is available" : "CAA rotator is not available";
+#else
+            r.success = true;
+            r.payload = false;
+            r.message = "CAA rotator is not supported by this QHY SDK";
+#endif
+            return r;
+        }
+
+        // 34. 获取 CAA 旋转器角度范围和当前值
+        if (name == "GetCAARotator") {
+            if (!handle) {
+                r.success = false;
+                r.message = "GetCAARotator requires a valid device handle";
+                return r;
+            }
+#if defined(QUARCS_QHY_HAS_CONTROL_CAA_ROTATOR)
+            double minV = -360.0, maxV = 360.0, stepV = 1.0;
+            const uint32_t rangeRet = GetQHYCCDParamMinMaxStep(handle, CONTROL_CAA_ROTATOR, &minV, &maxV, &stepV);
+            const double cur = GetQHYCCDParam(handle, CONTROL_CAA_ROTATOR);
+            if (rangeRet != QHYCCD_SUCCESS || cur == QHYCCD_ERROR) {
+                r.success = false;
+                r.message = "GetQHYCCDParamMinMaxStep/CONTROL_CAA_ROTATOR failed";
+            } else {
+                SdkControlParamInfo info;
+                info.minValue = -360.0;
+                info.maxValue = 360.0;
+                info.step = stepV;
+                info.current = cur;
+                r.success = true;
+                r.payload = info;
+                r.message = "CAA rotator param info acquired";
+            }
+#else
+            r.success = false;
+            r.errorCode = SdkErrorCode::NotImplemented;
+            r.message = "CAA rotator is not supported by this QHY SDK";
+#endif
+            return r;
+        }
+
+        // 35. 设置 CAA 旋转器角度
+        if (name == "SetCAARotator") {
+            if (!handle) {
+                r.success = false;
+                r.message = "SetCAARotator requires a valid device handle";
+                return r;
+            }
+            double angle = 0.0;
+            if (!extractParam<double>(cmd.payload, angle, r, "angle")) {
+                return r;
+            }
+            if (angle < -360.0) angle = -360.0;
+            if (angle > 360.0) angle = 360.0;
+#if defined(QUARCS_QHY_HAS_CONTROL_CAA_ROTATOR)
+            const unsigned int ret = SetQHYCCDParam(handle, CONTROL_CAA_ROTATOR, angle);
+            return makeResultFromRet("SetQHYCCDParam CONTROL_CAA_ROTATOR", ret);
+#else
+            r.success = false;
+            r.errorCode = SdkErrorCode::NotImplemented;
+            r.message = "CAA rotator is not supported by this QHY SDK";
+            return r;
+#endif
         }
     }
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -251,6 +251,7 @@ enum class SystemNumber {
   CFW1 = 21,
   Focuser1 = 22,
   LensCover1 = 23,
+  CAA1 = 24,
 };
 
 typedef struct


### PR DESCRIPTION
基础：QHYCCD-QUARCS/QUARCS_QT-SeverProgram 主分支，版本 8eebefb992c17807e44db2e9aa6843e8708fa891（重构 MainWindow 分割功能并加强 INDI QHY 连接）。
- 为QHY主相机添加SDK CAA/旋转器角色处理功能，包括检测、注册、清理、缓存的角度/范围状态，以及用于范围/当前/累积偏移的WebSocket消息。
- 添加 SetCAARotator 和 getCAARotator 命令处理功能，支持角度限制以及前端成功/失败通知。
- 添加 QHY SDK 的自定义命令，用于 IsCAARotatorAvailable、GetCAARotator 和 SetCAARotator，并在 CMake 阶段通过 CONTROL_CAA_ROTATOR 能力检测进行保护。
- 扩展设备角色映射，支持旋转器/CAA插槽，并在SDK相机资源释放或断开连接时清理CAA状态。
- 将 MyClient 更新为使用 INDI 2.x 的值风格属性 API，添加属性大小检查，并将 BaseDevice 条目以共享副本形式存储，而非原始回调指针。
- 将 flatfield_batch_test 与更新后的后端模块所需的额外运行时/设备依赖项链接起来。